### PR TITLE
Topic/bug 30156 mainversion handling

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -23,7 +23,7 @@ object DebugBuild : BuildType({
 
     name = "Build [Debug]"
 
-    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private\n+:artifacts/testResults/**/*=>artifacts/testResults"
+    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private"
 
     vcs {
         root(DslContext.settingsRoot)
@@ -67,7 +67,7 @@ object ReleaseBuild : BuildType({
 
     name = "Build [Release]"
 
-    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private\n+:artifacts/testResults/**/*=>artifacts/testResults"
+    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private"
 
     vcs {
         root(DslContext.settingsRoot)
@@ -100,7 +100,7 @@ object PublicBuild : BuildType({
 
     name = "Build [Public]"
 
-    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private\n+:artifacts/testResults/**/*=>artifacts/testResults"
+    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private"
 
     vcs {
         root(DslContext.settingsRoot)
@@ -169,7 +169,7 @@ object PublicDeployment : BuildType({
 
             artifacts {
                 cleanDestination = true
-                artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private\n+:artifacts/testResults/**/*=>artifacts/testResults"
+                artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private"
             }
         }
 

--- a/eng/MainVersion.props
+++ b/eng/MainVersion.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <MainVersion>1.0.59</MainVersion>
-        <PackageVersionSuffix>-preview</PackageVersionSuffix>
+        <MainVersion>1.0.58</MainVersion>
+        <PackageVersionSuffix>-beta</PackageVersionSuffix>
     </PropertyGroup>
 </Project>

--- a/eng/MainVersion.props
+++ b/eng/MainVersion.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <MainVersion>1.0.59</MainVersion>
-        <PackageVersionSuffix>-beta-3</PackageVersionSuffix>
+        <MainVersion>1.0.58</MainVersion>
+        <PackageVersionSuffix>-preview</PackageVersionSuffix>
     </PropertyGroup>
 </Project>

--- a/eng/MainVersion.props
+++ b/eng/MainVersion.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <MainVersion>1.0.58</MainVersion>
-        <PackageVersionSuffix>-beta</PackageVersionSuffix>
+        <MainVersion>1.0.59</MainVersion>
+        <PackageVersionSuffix>-beta-3</PackageVersionSuffix>
     </PropertyGroup>
 </Project>

--- a/eng/MainVersion.props
+++ b/eng/MainVersion.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <MainVersion>1.0.58</MainVersion>
+        <MainVersion>1.0.59</MainVersion>
         <PackageVersionSuffix>-preview</PackageVersionSuffix>
     </PropertyGroup>
 </Project>

--- a/src/PostSharp.Engineering.BuildTools/Build/BaseBuildSettings.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/BaseBuildSettings.cs
@@ -12,7 +12,7 @@ public class BaseBuildSettings : CommonCommandSettings
 {
     private BuildConfiguration? _resolvedConfiguration;
 
-    [Obsolete("Use the BuildConfiguration property. ")]
+    [Obsolete( "Use the BuildConfiguration property. " )]
     [Description( "Sets the build configuration (Debug | Release | Public)" )]
     [CommandOption( "-c|--configuration" )]
     public BuildConfiguration? ExplicitBuildConfiguration { get; set; }
@@ -33,6 +33,10 @@ public class BaseBuildSettings : CommonCommandSettings
 
     [Obsolete( "Use the BuildConfiguration property." )]
     public BuildConfiguration ResolvedBuildConfiguration => this.BuildConfiguration;
+
+    [Description( "Simulate a continuous integration build by setting the build ContinuousIntegrationBuild properyt to TRUE." )]
+    [CommandOption( "--ci" )]
+    public bool ContinuousIntegration { get; set; }
 
     public override void Initialize( BuildContext context )
     {

--- a/src/PostSharp.Engineering.BuildTools/Build/BuildSettings.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/BuildSettings.cs
@@ -30,10 +30,6 @@ namespace PostSharp.Engineering.BuildTools.Build
         [Description( "Disables concurrent processing" )]
         [CommandOption( "--no-concurrency" )]
         public bool NoConcurrency { get; set; }
-        
-        [Description("Simulate a continuous integration build by setting the build ContinuousIntegrationBuild properyt to TRUE.")]
-        [CommandOption("--ci")]
-        public bool ContinuousIntegration { get; set; }
 
         public BuildSettings WithIncludeTests( bool value )
         {
@@ -63,9 +59,9 @@ namespace PostSharp.Engineering.BuildTools.Build
 
             return clone;
         }
-        
+
         public VersionSpec GetVersionSpec( BuildConfiguration configuration )
-            => configuration == Build.BuildConfiguration.Public
+            => configuration == BuildConfiguration.Public
                 ? new VersionSpec( VersionKind.Public )
                 : this.BuildNumber > 0
                     ? new VersionSpec( VersionKind.Numbered, this.BuildNumber )

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -755,7 +755,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
             if ( this.MainVersionDependency != null )
             {
-                // If the MainVersionDependency is defined, we set the MainVersion to dependency MainVersion.
+                // If the MainVersionDependency is defined, we set the MainVersion to dependency version.
                 if ( !GetMainVersionDependencyVersion( context, this.MainVersionDependency, versionsOverrideFile, ref mainVersion ) )
                 {
                     return false;

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -20,7 +20,6 @@ using System.Reflection;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
-using Project = Microsoft.Build.Evaluation.Project;
 
 namespace PostSharp.Engineering.BuildTools.Build.Model
 {
@@ -114,24 +113,6 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         {
             var configuration = settings.BuildConfiguration;
             var buildConfigurationInfo = this.Configurations[configuration];
-
-            // The build for public configuration will not be run on TeamCity if there are no changes since the last version tag.
-            if ( TeamCityHelper.IsTeamCityBuild && configuration == BuildConfiguration.Public )
-            {
-                if ( !settings.Force )
-                {
-                    // Get the latest version tag.
-                    TryGetLastVersionTag( context, out var versionTag );
-
-                    // If there are no changes since the last tag (i.e. last publishing) the build will end successfully here.
-                    if ( !AreChangesSinceLastVersionTag( context, versionTag ) )
-                    {
-                        context.Console.WriteError( "Public build cannot be done because there are no new unpublished changes since the last version tag. Use --force." );
-
-                        return true;
-                    }
-                }
-            }
 
             // Build dependencies.
             if ( !settings.NoDependencies && !this.Prepare( context, settings ) )
@@ -433,7 +414,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             return new BuildInfo( packageVersion, Enum.Parse<BuildConfiguration>( configuration ), this );
         }
 
-        private static (string MainVersion, string? OverriddenPatchVersion, string PackageVersionSuffix) ReadMainVersionFile( string path )
+        private static (string MainVersion, string? OverriddenPatchVersion, string PackageVersionSuffix, int? OutPatchVersion ) ReadMainVersionFile(
+            string path )
         {
             var versionFilePath = path;
             var versionFile = Project.FromFile( versionFilePath, new ProjectOptions() );
@@ -446,6 +428,11 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             var overriddenPatchVersion = versionFile
                 .Properties
                 .SingleOrDefault( p => p.Name == "OverriddenPatchVersion" )
+                ?.EvaluatedValue;
+
+            var ourPatchVersion = versionFile
+                .Properties
+                .SingleOrDefault( p => p.Name == "OurPatchVersion" )
                 ?.EvaluatedValue;
 
             if ( string.IsNullOrEmpty( mainVersion ) )
@@ -463,7 +450,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
             ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
 
-            return (mainVersion, overriddenPatchVersion, suffix);
+            return (mainVersion, overriddenPatchVersion, suffix, ourPatchVersion != null ? int.Parse( ourPatchVersion, CultureInfo.InvariantCulture ) : null);
         }
 
         /// <summary>
@@ -745,7 +732,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             string? mainPackageVersionSuffix;
             string? overriddenPatchVersion;
 
-            (mainVersion, overriddenPatchVersion, mainPackageVersionSuffix) =
+            var mainVersionFile =
                 ReadMainVersionFile(
                     Path.Combine(
                         context.RepoDirectory,
@@ -790,15 +777,16 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
             }
 
-            if ( !string.IsNullOrWhiteSpace( overriddenPatchVersion ) && !overriddenPatchVersion.StartsWith( mainVersion + ".", StringComparison.Ordinal ) )
+            if ( !string.IsNullOrWhiteSpace( mainVersionFile.OverriddenPatchVersion )
+                 && !mainVersionFile.OverriddenPatchVersion.StartsWith( mainVersionFile.MainVersion + ".", StringComparison.Ordinal ) )
             {
                 context.Console.WriteError(
-                    $"The OverriddenPatchVersion property in MainVersion.props ({overriddenPatchVersion}) does not match the MainVersion property value ({mainVersion})." );
+                    $"The OverriddenPatchVersion property in MainVersion.props ({mainVersionFile.OverriddenPatchVersion}) does not match the MainVersion property value ({mainVersionFile.MainVersion})." );
 
                 return false;
             }
 
-            var versionPrefix = mainVersion;
+            var versionPrefix = mainVersionFile.MainVersion;
             string versionSuffix;
             int patchNumber;
 
@@ -862,12 +850,12 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
                 case VersionKind.Public:
                     // Public build
-                    versionSuffix = mainPackageVersionSuffix.TrimStart( '-' );
+                    versionSuffix = mainVersionFile.PackageVersionSuffix.TrimStart( '-' );
                     patchNumber = 0;
 
-                    if ( !string.IsNullOrWhiteSpace( overriddenPatchVersion ) )
+                    if ( !string.IsNullOrWhiteSpace( mainVersionFile.OverriddenPatchVersion ) )
                     {
-                        var parsedOverriddenPatchedVersion = Version.Parse( overriddenPatchVersion );
+                        var parsedOverriddenPatchedVersion = Version.Parse( mainVersionFile.OverriddenPatchVersion );
                         patchNumber = parsedOverriddenPatchedVersion.Revision;
                     }
 
@@ -877,7 +865,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                     throw new InvalidOperationException();
             }
 
-            version = new VersionComponents( mainVersion, versionPrefix, patchNumber, versionSuffix );
+            version = new VersionComponents( mainVersionFile.MainVersion, versionPrefix, patchNumber, versionSuffix );
 
             return true;
         }
@@ -1113,7 +1101,11 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 this.MainVersionFile );
 
             // Get the current version from MainVersion.props.
-            if ( !this.TryLoadMainVersion( context, configuration, mainVersionFile, out var currentVersion, out var ourPatchVersion, out var packageVersionSuffix ) )
+            if ( !this.TryLoadMainVersion(
+                    context,
+                    configuration,
+                    mainVersionFile,
+                    out var mainVersionInfo ) )
             {
                 return false;
             }
@@ -1130,13 +1122,14 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 // If there are no changes since the last tag (i.e. last publishing) the publishing will end successfully here.
                 if ( !AreChangesSinceLastVersionTag( context, lastVersionTag ) )
                 {
-                    context.Console.WriteError( "Publishing cannot be done because there are no new unpublished changes since the last version tag. Use --force." );
+                    context.Console.WriteWarning(
+                        "Publishing is skipped because there are no new unpublished changes since the last version tag. Use --force." );
 
                     return true;
                 }
 
                 // If version has not been bumped since the last publish, it requires manual bump and therefore the version can't be published.
-                if ( !IsVersionBumped( context, currentVersion, lastVersionTag ) )
+                if ( !IsVersionBumped( context, mainVersionInfo.Version, lastVersionTag ) )
                 {
                     return false;
                 }
@@ -1148,7 +1141,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             }
 
             context.Console.WriteHeading( "Publishing files" );
-            
+
             if ( !Publisher.PublishDirectory(
                     context,
                     settings,
@@ -1183,16 +1176,16 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             }
 
             // After successful artifact publishing the last commit is tagged with current version tag.
-            if ( !AddTagToLastCommit( context, currentVersion, packageVersionSuffix ) )
+            if ( !AddTagToLastCommit( context, mainVersionInfo, settings ) )
             {
                 return false;
             }
 
-            // If MainVersionDependency is defined we don't do the VersionBump.
+            // If MainVersionDependency is not defined we don't do the VersionBump.
             if ( this.MainVersionDependency == null )
             {
                 // MainVersion.props version is bumped and pushed to the repository.
-                if ( !this.BumpVersion( context, mainVersionFile, currentVersion, ourPatchVersion, packageVersionSuffix ) )
+                if ( !this.TryBumpVersion( context, mainVersionFile, mainVersionInfo, settings ) )
                 {
                     return false;
                 }
@@ -1364,14 +1357,15 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
             if ( string.IsNullOrEmpty( lastVersionTag ) )
             {
-                context.Console.WriteWarning( "There is no version tag in this repository. For clean repositories tag the initial commit with 0.0.0 version tag." );
+                context.Console.WriteWarning(
+                    "There is no version tag in this repository. For clean repositories tag the initial commit with 0.0.0 version tag." );
 
                 return false;
             }
 
             return true;
         }
-        
+
         private static bool AreChangesSinceLastVersionTag( BuildContext context, string? lastVersionTag )
         {
             // Gets the count from list of committed changes between last version tag and current HEAD excluding version bumps.
@@ -1432,9 +1426,9 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             return true;
         }
 
-        private static bool AddTagToLastCommit( BuildContext context, Version? version, string? packageVersionSuffix )
+        private static bool AddTagToLastCommit( BuildContext context, MainVersionInfo mainVersionInfo, BaseBuildSettings settings )
         {
-            var versionTag = string.Concat( version, packageVersionSuffix );
+            var versionTag = string.Concat( mainVersionInfo.Version, mainVersionInfo.PackageVersionSuffix );
 
             // Tagging the last commit with version.
             if ( !ToolInvocationHelper.InvokeTool(
@@ -1462,13 +1456,16 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             var isHttps = gitOrigin.StartsWith( "https", StringComparison.InvariantCulture );
 
             // When on TeamCity, if the repository is of HTTPS origin, the origin will be updated to form including Git authentication credentials.
-            if ( TeamCityHelper.IsTeamCityBuild )
+            if ( TeamCityHelper.IsTeamCityBuild( settings ) )
             {
                 if ( isHttps )
                 {
-                    if ( !TeamCityHelper.TryGetTeamCitySourceWriteToken( out var teamcitySourceWriteTokenEnvironmentVariableName, out var teamcitySourceCodeWritingToken ) )
+                    if ( !TeamCityHelper.TryGetTeamCitySourceWriteToken(
+                            out var teamcitySourceWriteTokenEnvironmentVariableName,
+                            out var teamcitySourceCodeWritingToken ) )
                     {
-                        context.Console.WriteImportantMessage( $"{teamcitySourceWriteTokenEnvironmentVariableName} environment variable is not set. Using default credentials." );
+                        context.Console.WriteImportantMessage(
+                            $"{teamcitySourceWriteTokenEnvironmentVariableName} environment variable is not set. Using default credentials." );
                     }
                     else
                     {
@@ -1479,7 +1476,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
             // Pushes tag to origin.
             if ( !ToolInvocationHelper.InvokeTool(
-                    context.Console, 
+                    context.Console,
                     "git",
                     $"push {gitOrigin} {versionTag}",
                     context.RepoDirectory ) )
@@ -1492,7 +1489,11 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             return true;
         }
 
-        private bool BumpVersion( BuildContext context, string mainVersionFile, Version currentVersion, int ourPatchVersion, string packageVersionSuffix )
+        private bool TryBumpVersion(
+            BuildContext context,
+            string mainVersionFile,
+            MainVersionInfo currentMainVersionInfo,
+            PublishSettings settings )
         {
             if ( !File.Exists( mainVersionFile ) )
             {
@@ -1502,31 +1503,33 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             }
 
             // Increment the version.
-            if ( !IncrementVersion( currentVersion, out var newVersion, ref ourPatchVersion ) )
-            {
-                context.Console.WriteError( $"Could not increment version '{currentVersion}'." );
+            var newVersion = new Version(
+                currentMainVersionInfo.Version.Major,
+                currentMainVersionInfo.Version.Minor,
+                currentMainVersionInfo.Version.Build + 1 );
 
-                return false;
-            }
+            var newPatchNumber = currentMainVersionInfo.OurPatchVersion != null ? currentMainVersionInfo.OurPatchVersion + 1 : null;
+            var newMainVersionInfo = new MainVersionInfo( newVersion, currentMainVersionInfo.PackageVersionSuffix, newPatchNumber );
 
             // Save the MainVersion.props with new version.
-            if ( !TrySaveMainVersion( context, mainVersionFile, newVersion, ourPatchVersion, packageVersionSuffix ) )
+            if ( !TrySaveMainVersion( context, mainVersionFile, newMainVersionInfo ) )
             {
                 return false;
             }
 
             // Commit the version bump.
-            if ( !this.TryCommitVersionBump( context, currentVersion, newVersion ) )
-            {   
+            if ( !this.TryCommitVersionBump( context, currentMainVersionInfo.Version, newVersion, settings ) )
+            {
                 return false;
             }
 
-            context.Console.WriteSuccess( $"Bumping the '{context.Product.ProductName}' version from '{currentVersion}{packageVersionSuffix}' to '{newVersion}{packageVersionSuffix}' was successful." );
+            context.Console.WriteSuccess(
+                $"Bumping the '{context.Product.ProductName}' version from '{currentMainVersionInfo.Version}{currentMainVersionInfo.PackageVersionSuffix}' to '{newMainVersionInfo.Version}{newMainVersionInfo.PackageVersionSuffix}' was successful." );
 
             return true;
         }
 
-        private bool TryCommitVersionBump( BuildContext context, Version currentVersion, Version newVersion )
+        private bool TryCommitVersionBump( BuildContext context, Version currentVersion, Version newVersion, BaseBuildSettings settings )
         {
             // Adds bumped MainVersion.props to Git staging area.
             if ( !ToolInvocationHelper.InvokeTool(
@@ -1558,7 +1561,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             var isHttps = gitOrigin.StartsWith( "https", StringComparison.InvariantCulture );
 
             // When on TeamCity, Git user credentials are set to TeamCity and if the repository is of HTTPS origin, the origin will be updated to form including Git authentication credentials.
-            if ( TeamCityHelper.IsTeamCityBuild )
+            if ( TeamCityHelper.IsTeamCityBuild( settings ) )
             {
                 // Following configurations are set only for the current operations in the repository.
                 if ( !ToolInvocationHelper.InvokeTool(
@@ -1581,9 +1584,12 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
                 if ( isHttps )
                 {
-                    if ( !TeamCityHelper.TryGetTeamCitySourceWriteToken( out var teamcitySourceWriteTokenEnvironmentVariableName, out var teamcitySourceCodeWritingToken ) )
+                    if ( !TeamCityHelper.TryGetTeamCitySourceWriteToken(
+                            out var teamcitySourceWriteTokenEnvironmentVariableName,
+                            out var teamcitySourceCodeWritingToken ) )
                     {
-                        context.Console.WriteImportantMessage( $"{teamcitySourceWriteTokenEnvironmentVariableName} environment variable is not set. Using default credentials." );
+                        context.Console.WriteImportantMessage(
+                            $"{teamcitySourceWriteTokenEnvironmentVariableName} environment variable is not set. Using default credentials." );
                     }
                     else
                     {
@@ -1593,7 +1599,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             }
 
             if ( !ToolInvocationHelper.InvokeTool(
-                    context.Console, 
+                    context.Console,
                     "git",
                     $"commit -m \"<<VERSION_BUMP>> {currentVersion} to {newVersion}\"",
                     context.RepoDirectory ) )
@@ -1613,58 +1619,25 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             return true;
         }
 
-        private static bool IncrementVersion( Version currentVersion, out Version newVersion, ref int ourPatchNumber )
-        {
-            var major = currentVersion.Major;
-            var minor = currentVersion.Minor;
-            var build = currentVersion.Build;
-
-            // If our patch version has any positive value including zero, it is incremented.
-            if ( ourPatchNumber != -1 )
-            {
-                ourPatchNumber++;
-            }
-
-            build++;
-
-            newVersion = new Version( major, minor, build );
-
-            return true;
-        }
+        private record MainVersionInfo( Version Version, string PackageVersionSuffix, int? OurPatchVersion );
 
         private bool TryLoadMainVersion(
             BuildContext context,
             BuildConfiguration configuration,
             string mainVersionFile,
-            [NotNullWhen( true )] out Version? currentVersion,
-            out int ourPatchVersion,
-            out string packageVersionSuffix )
+            [NotNullWhen( true )] out MainVersionInfo? mainVersionInfo )
         {
             var version = ReadMainVersionFile( mainVersionFile );
             var mainVersion = version.MainVersion;
             var overriddenPatchVersion = version.OverriddenPatchVersion;
-            packageVersionSuffix = version.PackageVersionSuffix;
-            currentVersion = null;
-            ourPatchVersion = -1;
+            Version? currentVersion;
 
             // The MainVersionDependency is not defined.
             if ( this.MainVersionDependency == null )
             {
-                var document = XDocument.Load( mainVersionFile );
-                var project = document.Root;
-                var properties = project?.Element( "PropertyGroup" );
-                var ourPatchVersionString = properties?.Element( "OurPatchVersion" )?.Value;
-    
                 // The current version defaults to MainVersion.
-                currentVersion = Version.Parse( mainVersion );
-                
-                // Our patch version is defined.
-                if ( ourPatchVersionString != null )
-                {
-                    ourPatchVersion = int.Parse( ourPatchVersionString, CultureInfo.InvariantCulture );
-                }
 
-                return true;
+                currentVersion = Version.Parse( mainVersion );
             }
             else
             {
@@ -1672,38 +1645,49 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 if ( overriddenPatchVersion != null )
                 {
                     currentVersion = new Version( overriddenPatchVersion );
-
-                    return true;
                 }
-
-                // If no OverridenPatchVersion is defined, we use MainVersion property from private artifact.
-                var artifactVersionFile = Path.Combine(
-                    context.RepoDirectory,
-                    context.Product.PrivateArtifactsDirectory.ToString(),
-                    context.Product.ProductName + ".version.props" );
-
-                var document = XDocument.Load( artifactVersionFile );
-                var project = document.Root;
-                var properties = project?.Element( "PropertyGroup" );
-                mainVersion = properties?.Element( $"{context.Product.ProductNameWithoutDot}MainVersion" )?.Value;
-
-                // Set the current version to dependency version.
-                if ( mainVersion != null )
+                else
                 {
+                    // If no OverridenPatchVersion is defined, we use MainVersion property from private artifact.
+
+                    var artifactVersionFile = Path.Combine(
+                        context.RepoDirectory,
+                        context.Product.PrivateArtifactsDirectory.ToString(),
+                        context.Product.ProductName + ".version.props" );
+
+                    var document = XDocument.Load( artifactVersionFile );
+                    var project = document.Root;
+                    var properties = project?.Element( "PropertyGroup" );
+                    var propertyName = $"{context.Product.ProductNameWithoutDot}MainVersion";
+                    mainVersion = properties?.Element( propertyName )?.Value;
+
+                    if ( mainVersion == null )
+                    {
+                        context.Console.WriteError( $"The property '{propertyName}' in '{artifactVersionFile}' is not defined." );
+
+                        mainVersionInfo = null;
+
+                        return false;
+                    }
+
+                    // Set the current version to dependency version.
                     currentVersion = new Version( mainVersion );
-
-                    return true;
                 }
-
-                return false;
             }
+
+            mainVersionInfo = new MainVersionInfo( currentVersion, version.PackageVersionSuffix, version.OutPatchVersion );
+
+            return true;
         }
 
-        private static bool TrySaveMainVersion( BuildContext context, string mainVersionFile, Version version, int ourPatchVersion, string packageVersionSuffix )
+        private static bool TrySaveMainVersion(
+            BuildContext context,
+            string mainVersionFile,
+            MainVersionInfo mainVersionInfo )
         {
             if ( !File.Exists( mainVersionFile ) )
             {
-                context.Console.WriteError( $"Could not save '{mainVersionFile}' with version '{version}'." );
+                context.Console.WriteError( $"Could not save '{mainVersionFile}': the file does not exist." );
 
                 return false;
             }
@@ -1716,21 +1700,22 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             var packageVersionSuffixElement = properties.Element( "PackageVersionSuffix" );
 
             // If OurPatchVersion is defined in MainVersion.props, we write the incremented patch number to it.
-            if ( ourPatchVersion != -1 && ourPatchVersionElement != null )
+            if ( mainVersionInfo.OurPatchVersion != null && ourPatchVersionElement != null )
             {
-                ourPatchVersionElement.Value = ourPatchVersion.ToString( CultureInfo.InvariantCulture );
+                ourPatchVersionElement.Value = mainVersionInfo.OurPatchVersion.Value.ToString( CultureInfo.InvariantCulture );
             }
-            
+
             // Otherwise we replace the whole MainVersion with new version.
             else
             {
-                mainVersionElement!.Value = version.ToString();
+                mainVersionElement!.Value = mainVersionInfo.Version.ToString();
             }
 
-            packageVersionSuffixElement!.Value = packageVersionSuffix;
+            packageVersionSuffixElement!.Value = mainVersionInfo.PackageVersionSuffix;
 
             // Using settings to keep the indentation as well as encoding identical to original MainVersion.props.
-            var xmlWriterSettings = new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true, IndentChars = "    ", Encoding = new UTF8Encoding( false ) };
+            var xmlWriterSettings =
+                new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true, IndentChars = "    ", Encoding = new UTF8Encoding( false ) };
 
             using ( var xmlWriter = XmlWriter.Create( mainVersionFile, xmlWriterSettings ) )
             {

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1645,8 +1645,6 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             var mainVersion = version.MainVersion;
             var overriddenPatchVersion = version.OverriddenPatchVersion;
             packageVersionSuffix = version.PackageVersionSuffix;
-
-            currentVersion = null;
             ourPatchVersion = -1;
 
             var mainVersionDependency = this.MainVersionDependency;
@@ -1673,7 +1671,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             else
             {
                 // If MainVersionDependency and OverriddenPatchVersion properties are defined, we use OverriddenPatchVersion value.
-                if ( overriddenPatchVersion != null )
+                if ( version.OverriddenPatchVersion != null )
                 {
                     currentVersion = new Version( overriddenPatchVersion );
 
@@ -1684,17 +1682,16 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 var artifactVersionFile = Path.Combine(
                     context.RepoDirectory,
                     context.Product.PrivateArtifactsDirectory.ToString(),
-                    context.Product.ProductName,
-                    ".version.props" );
+                    context.Product.ProductName + ".version.props" );
 
                 var document = XDocument.Load( artifactVersionFile );
                 var project = document.Root;
                 var properties = project?.Element( "PropertyGroup" );
-                var ver = properties?.Element( $"{context.Product.ProductNameWithoutDot}Version" )?.Value;
+                var ver = properties?.Element( $"{context.Product.ProductNameWithoutDot}MainVersion" )?.Value;
                 Console.WriteLine( ver );
 
                 // Set the current version to dependency version.
-                currentVersion = new Version( mainVersion );
+                currentVersion = new Version( ver );
 
                 return true;
             }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1152,23 +1152,19 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 context.Console.WriteSuccess( "Publishing has succeeded." );
             }
 
-            // Only Public build will tag and version bump. This is to prevent changes in the original repository by publishing beta packages of PostSharp.Engineering under Debug configuration used for testing on TeamCity.
-            if ( configuration == BuildConfiguration.Public )
+            // After successful artifact publishing the last commit is tagged with current version tag.
+            if ( !AddTagToLastCommit( context, currentVersion, packageVersionSuffix ) )
             {
-                // After successful artifact publishing the last commit is tagged with current version tag.
-                if ( !AddTagToLastCommit( context, currentVersion, packageVersionSuffix ) )
+                return false;
+            }
+
+            // If MainVersionDependency is defined we don't do the VersionBump.
+            if ( this.MainVersionDependency == null )
+            {
+                // MainVersion.props version is bumped and pushed to the repository.
+                if ( !this.BumpVersion( context, mainVersionFile, currentVersion, ourPatchVersion, packageVersionSuffix ) )
                 {
                     return false;
-                }
-
-                // If MainVersionDependency is defined we don't do the VersionBump.
-                if ( this.MainVersionDependency == null )
-                {
-                    // MainVersion.props version is bumped and pushed to the repository.
-                    if ( !this.BumpVersion( context, mainVersionFile, currentVersion, ourPatchVersion, packageVersionSuffix ) )
-                    {
-                        return false;
-                    }
                 }
             }
 

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/TestDependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/TestDependencies.cs
@@ -4,7 +4,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model;
 
 public static class TestDependencies
 {
-    public static DependencyDefinition Product { get; } = new(
+    public static DependencyDefinition TestProduct { get; } = new(
         "PostSharp.Engineering.Test.TestProduct",
         VcsProvider.AzureRepos,
         "postsharp",
@@ -27,10 +27,24 @@ public static class TestDependencies
         VcsProvider.GitHub,
         "postsharp",
         ("Test_PostSharpEngineeringTestGitHub_DebugBuild", "Test_PostSharpEngineeringTestGitHub_ReleaseBuild", "Test_PostSharpEngineeringTestGitHub_PublicBuild") );
+    
+    public static DependencyDefinition MainVersionDependency { get; } = new(
+        "PostSharp.Engineering.Test.MainVersionDependency",
+        VcsProvider.AzureRepos,
+        "postsharp",
+        ("Test_PostSharpEngineeringTestMainVersionDependency_DebugBuild", "Test_PostSharpEngineeringTestMainVersionDependency_ReleaseBuild", "Test_PostSharpEngineeringTestMainVersionDependency_PublicBuild") );
+    
+    public static DependencyDefinition PatchVersion { get; } = new(
+        "PostSharp.Engineering.Test.PatchVersion",
+        VcsProvider.AzureRepos,
+        "postsharp",
+        ("Test_PostSharpEngineeringTestPatchVersion_DebugBuild", "Test_PostSharpEngineeringTestPatchVersion_ReleaseBuild", "Test_PostSharpEngineeringTestPatchVersion_PublicBuild") );
 
     public static ImmutableArray<DependencyDefinition> All { get; } = ImmutableArray.Create(
-        Product,
+        TestProduct,
         Dependency,
         TransitiveDependency,
-        GitHub );
+        GitHub,
+        MainVersionDependency,
+        PatchVersion );
 }

--- a/src/PostSharp.Engineering.BuildTools/Utilities/TeamCityHelper.cs
+++ b/src/PostSharp.Engineering.BuildTools/Utilities/TeamCityHelper.cs
@@ -1,12 +1,14 @@
-﻿using System;
+﻿using PostSharp.Engineering.BuildTools.Build;
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace PostSharp.Engineering.BuildTools.Utilities;
 
 public static class TeamCityHelper
 {
-    public static bool IsTeamCityBuild { get; } = Environment.GetEnvironmentVariable( "TEAMCITY_GIT_PATH" ) != null;
-    
+    public static bool IsTeamCityBuild( BaseBuildSettings settings )
+        => settings.ContinuousIntegration || Environment.GetEnvironmentVariable( "TEAMCITY_GIT_PATH" ) != null;
+
     public static bool TryGetTeamCitySourceWriteToken( out string environmentVariableName, [NotNullWhen( true )] out string? teamCitySourceWriteToken )
     {
         environmentVariableName = "TEAMCITY_SOURCE_WRITE_TOKEN";


### PR DESCRIPTION
1. The testResults artifacts are now enable-able throughought setting Product.PublishTestResults = true.

2. PatchVersion renamed to OverriddenPatchVersion.

3. All three kinds of versions (normal, OurPatchVersion aka Compiler, and MainVersionDependency aka VSX) are now being handled. First one is trivial, Compiler-type is Version-bumping only OurPatchVersion and VSX-type is not bumping but the tag is being taken a) from OverriddenPatchVersion or b) from MainVersion of the MainVersionDependency product

4. Public build is now limit-less, only TeamCity will fail Public build if there are no changes.