### PR TITLE
Added option to add SSH Agent into TeamCity settings

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -3,6 +3,7 @@
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 
 // Both Swabra and swabra need to be imported
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.sshAgent
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.Swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
@@ -157,6 +158,9 @@ object PublicDeployment : BuildType({
         swabra {
             lockingProcesses = Swabra.LockingProcessPolicy.KILL
             verbose = true
+        }
+        sshAgent {
+            teamcitySshKey = "PostSharp.Engineering"
         }
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -160,6 +160,7 @@ object PublicDeployment : BuildType({
             verbose = true
         }
         sshAgent {
+            // By convention, the SSH key name is the same as the product name.
             teamcitySshKey = "PostSharp.Engineering"
         }
     }

--- a/eng/MainVersion.props
+++ b/eng/MainVersion.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <MainVersion>1.0.59</MainVersion>
+        <MainVersion>1.0.60</MainVersion>
         <PackageVersionSuffix>-preview</PackageVersionSuffix>
     </PropertyGroup>
 </Project>

--- a/eng/src/Program.cs
+++ b/eng/src/Program.cs
@@ -3,6 +3,7 @@
 using PostSharp.Engineering.BuildTools;
 using PostSharp.Engineering.BuildTools.Build.Model;
 using PostSharp.Engineering.BuildTools.Build.Solutions;
+using PostSharp.Engineering.BuildTools.Dependencies.Model;
 using Spectre.Console.Cli;
 
 var product = new Product
@@ -13,7 +14,8 @@ var product = new Product
         "PostSharp.Engineering.Sdk.$(PackageVersion).nupkg",
         "PostSharp.Engineering.BuildTools.$(PackageVersion).nupkg",
         "PostSharp.Engineering.BuildTools.AWS.$(PackageVersion).nupkg" ),
-    RequiresEngineeringSdk = false
+    RequiresEngineeringSdk = false,
+    VcsProvider = VcsProvider.GitHub
 };
 
 var commandApp = new CommandApp();

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -78,6 +78,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         public bool PublishTestResults { get; init; }
 
         public bool RequiresBranchMerging { get; init; }
+        
+        public VcsProvider VcsProvider { get; init; }
 
         public bool KeepEditorConfig { get; init; }
 
@@ -1315,7 +1317,10 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                         buildArguments: $"publish --configuration {configuration}",
                         buildAgentType: this.BuildAgentType )
                     {
-                        IsDeployment = true, ArtifactDependencies = new[] { (buildTeamCityConfiguration.ObjectName, artifactRules) }
+                        ProductName = context.Product.ProductName,
+                        SshAgentRequired = this.VcsProvider == VcsProvider.GitHub,
+                        IsDeployment = true,
+                        ArtifactDependencies = new[] { (buildTeamCityConfiguration.ObjectName, artifactRules) }
                     };
 
                     teamCityBuildConfigurations.Add( teamCityDeploymentConfiguration );

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1290,6 +1290,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                     $@"+:{publicArtifactsDirectory}/**/*=>{publicArtifactsDirectory}\n+:{privateArtifactsDirectory}/**/*=>{privateArtifactsDirectory}{(this.PublishTestResults ? $@"\n+:{testResultsDirectory}/**/*=>{testResultsDirectory}" : "")}";
 
                 var buildTeamCityConfiguration = new TeamCityBuildConfiguration(
+                    this,
                     objectName: $"{configuration}Build",
                     name: configurationInfo.TeamCityBuildName ?? $"Build [{configuration}]",
                     buildArguments: $"test --configuration {configuration} --buildNumber %build.number%",
@@ -1312,13 +1313,12 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                      || configurationInfo.PublicPublishers != null )
                 {
                     teamCityDeploymentConfiguration = new TeamCityBuildConfiguration(
+                        this,
                         objectName: $"{configuration}Deployment",
                         name: configurationInfo.TeamCityDeploymentName ?? $"Deploy [{configuration}]",
                         buildArguments: $"publish --configuration {configuration}",
                         buildAgentType: this.BuildAgentType )
                     {
-                        ProductName = context.Product.ProductName,
-                        SshAgentRequired = this.VcsProvider == VcsProvider.GitHub,
                         IsDeployment = true,
                         ArtifactDependencies = new[] { (buildTeamCityConfiguration.ObjectName, artifactRules) }
                     };
@@ -1330,6 +1330,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 {
                     teamCityBuildConfigurations.Add(
                         new TeamCityBuildConfiguration(
+                            this,
                             objectName: $"{configuration}Swap",
                             name: configurationInfo.TeamCitySwapName ?? $"Swap [{configuration}]",
                             buildArguments: $"swap --configuration {configuration}",

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -78,8 +78,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         public bool PublishTestResults { get; init; }
 
         public bool RequiresBranchMerging { get; init; }
-        
-        public VcsProvider VcsProvider { get; init; }
+
+        public VcsProvider? VcsProvider { get; init; }
 
         public bool KeepEditorConfig { get; init; }
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
@@ -5,6 +5,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
     internal class TeamCityBuildConfiguration
     {
         public Product Product { get; }
+
         public string ObjectName { get; }
 
         public string Name { get; }
@@ -87,11 +88,14 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             verbose = true
         }}" );
 
-            if ( this.IsDeployment && this.Product.VcsProvider.SshAgentRequired )
+            var productVcsProvider = this.Product.VcsProvider;
+            
+            // The SSH agent is added only for the Deployment and only if TeamCity needs it to use Git operations on the VCS repository.
+            if ( productVcsProvider != null && this.IsDeployment && productVcsProvider.SshAgentRequired )
             {
                 writer.WriteLine(
                     $@"        sshAgent {{
-            // By convention, the ssh key name is the same as the product name.
+            // By convention, the SSH key name is the same as the product name.
             teamcitySshKey = ""{this.Product.ProductName}""
         }}" );
             }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
@@ -14,6 +14,10 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
         public bool IsDeployment { get; init; }
 
+        public string? ProductName { get; init; }
+
+        public bool SshAgentRequired { get; init; }
+
         public string? ArtifactRules { get; init; }
 
         public string[]? AdditionalArtifactRules { get; init; }
@@ -83,8 +87,18 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         swabra {{
             lockingProcesses = Swabra.LockingProcessPolicy.KILL
             verbose = true
-        }}
-    }}" );
+        }}" );
+
+            if ( this.IsDeployment && this.SshAgentRequired )
+            {
+                writer.WriteLine(
+                    $@"        sshAgent {{
+            teamcitySshKey = ""{this.ProductName}""
+        }}" );
+            }
+
+            writer.WriteLine(
+                $@"    }}" );
 
             // Triggers.
             if ( this.BuildTriggers is { Length: > 0 } )

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
@@ -4,6 +4,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 {
     internal class TeamCityBuildConfiguration
     {
+        public Product Product { get; }
         public string ObjectName { get; }
 
         public string Name { get; }
@@ -13,11 +14,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         public string BuildAgentType { get; }
 
         public bool IsDeployment { get; init; }
-
-        public string? ProductName { get; init; }
-
-        public bool SshAgentRequired { get; init; }
-
+   
         public string? ArtifactRules { get; init; }
 
         public string[]? AdditionalArtifactRules { get; init; }
@@ -28,8 +25,9 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
         public (string ObjectName, string ArtifactRules)[]? ArtifactDependencies { get; init; }
 
-        public TeamCityBuildConfiguration( string objectName, string name, string buildArguments, string buildAgentType )
+        public TeamCityBuildConfiguration( Product product, string objectName, string name, string buildArguments, string buildAgentType )
         {
+            this.Product = product;
             this.ObjectName = objectName;
             this.Name = name;
             this.BuildArguments = buildArguments;
@@ -89,11 +87,12 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             verbose = true
         }}" );
 
-            if ( this.IsDeployment && this.SshAgentRequired )
+            if ( this.IsDeployment && this.Product.VcsProvider.SshAgentRequired )
             {
                 writer.WriteLine(
                     $@"        sshAgent {{
-            teamcitySshKey = ""{this.ProductName}""
+            // By convention, the ssh key name is the same as the product name.
+            teamcitySshKey = ""{this.Product.ProductName}""
         }}" );
             }
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityProject.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityProject.cs
@@ -20,6 +20,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 
 // Both Swabra and swabra need to be imported
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.sshAgent
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.Swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.swabra
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/VcsProvider.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/VcsProvider.cs
@@ -4,8 +4,8 @@
     {
         public bool SshAgentRequired { get; init; }
 
-        public static VcsProvider None = new VcsProvider();
-        public static VcsProvider GitHub = new VcsProvider() { SshAgentRequired = true };
-        public static VcsProvider AzureRepos = new VcsProvider();
+        public static readonly VcsProvider None = new VcsProvider();
+        public static readonly VcsProvider GitHub = new VcsProvider() { SshAgentRequired = true };
+        public static readonly VcsProvider AzureRepos = new VcsProvider();
     }
 }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/VcsProvider.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/VcsProvider.cs
@@ -1,9 +1,11 @@
 ﻿namespace PostSharp.Engineering.BuildTools.Dependencies.Model
 {
-    public enum VcsProvider
+    public class VcsProvider
     {
-        None,
-        GitHub,
-        AzureRepos
+        public bool SshAgentRequired { get; init; }
+
+        public static VcsProvider None = new VcsProvider();
+        public static VcsProvider GitHub = new VcsProvider() { SshAgentRequired = true };
+        public static VcsProvider AzureRepos = new VcsProvider();
     }
 }


### PR DESCRIPTION
If we have a GitHub repository, TeamCity needs to use an imported SSH key, for this it uses SSH Agent that needs to be configured for repositories that are on GitHub. Each SSH key has to have identical name to the repository.