### PR TITLE
Topic/story 30187 version bumping

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -197,7 +197,7 @@ object VersionBump : BuildType({
                 path = "Build.ps1"
             }
             noProfile = false
-            param("jetbrains_powershell_scriptArguments", "--version bump")
+            param("jetbrains_powershell_scriptArguments", "bump version")
         }
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -215,7 +215,7 @@ object VersionBump : BuildType({
     triggers {
 
         finishBuildTrigger {
-            buildType = "postsharp_PostSharpEngineering_VersionBump"
+            buildType = "postsharp_PostSharpEngineering_PublicDeployment"
             // Only successful deployment will trigger the version bump.
             successfulOnly = true
             branchFilter = "+:<default>"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -199,7 +199,7 @@ object VersionBump : BuildType({
                 path = "Build.ps1"
             }
             noProfile = false
-            param("jetbrains_powershell_scriptArguments", "bump version")
+            param("jetbrains_powershell_scriptArguments", "bump")
         }
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -160,9 +160,20 @@ object PublicDeployment : BuildType({
             verbose = true
         }
         sshAgent {
-            // By convention, the SSH key name is the same as the product name.
+            // By convention, the SSH key name is always PostSharp.Engineering for all repositories using SSH to connect.
             teamcitySshKey = "PostSharp.Engineering"
         }
+    }
+
+    triggers {
+
+        finishBuildTrigger {
+            buildType = "postsharp_PostSharpEngineering_Bump"
+            // Only successful build will trigger version bump.
+            watchChangesInDependencies = true
+            branchFilter = "+:<default>"
+        }        
+
     }
 
   dependencies {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -187,6 +187,8 @@ object VersionBump : BuildType({
 
     name = "Version Bump"
 
+    type = Type.DEPLOYMENT
+
     vcs {
         root(DslContext.settingsRoot)
     }
@@ -209,6 +211,10 @@ object VersionBump : BuildType({
         swabra {
             lockingProcesses = Swabra.LockingProcessPolicy.KILL
             verbose = true
+        }
+        sshAgent {
+            // By convention, the SSH key name is always PostSharp.Engineering for all repositories using SSH to connect.
+            teamcitySshKey = "PostSharp.Engineering"
         }
     }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -220,13 +220,6 @@ object VersionBump : BuildType({
 
     triggers {
 
-        finishBuildTrigger {
-            buildType = "postsharp_PostSharpEngineering_PublicDeployment"
-            // Only successful deployment will trigger the version bump.
-            successfulOnly = true
-            branchFilter = "+:<default>"
-        }        
-
     }
 
 })

--- a/eng/MainVersion.props
+++ b/eng/MainVersion.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <MainVersion>1.0.62</MainVersion>
+        <MainVersion>1.0.63</MainVersion>
         <PackageVersionSuffix>-preview</PackageVersionSuffix>
     </PropertyGroup>
 </Project>

--- a/eng/MainVersion.props
+++ b/eng/MainVersion.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <MainVersion>1.0.61</MainVersion>
-        <PackageVersionSuffix>-preview</PackageVersionSuffix>
+        <MainVersion>1.0.62</MainVersion>
+        <PackageVersionSuffix>-beta</PackageVersionSuffix>
     </PropertyGroup>
 </Project>

--- a/eng/MainVersion.props
+++ b/eng/MainVersion.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
         <MainVersion>1.0.62</MainVersion>
-        <PackageVersionSuffix>-beta</PackageVersionSuffix>
+        <PackageVersionSuffix>-preview</PackageVersionSuffix>
     </PropertyGroup>
 </Project>

--- a/eng/src/Program.cs
+++ b/eng/src/Program.cs
@@ -6,7 +6,7 @@ using PostSharp.Engineering.BuildTools.Build.Solutions;
 using PostSharp.Engineering.BuildTools.Dependencies.Model;
 using Spectre.Console.Cli;
 
-var product = new Product
+var product = new Product( Dependencies.PostSharpEngineering )
 {
     ProductName = "PostSharp.Engineering",
     Solutions = new Solution[] { new DotNetSolution( "PostSharp.Engineering.sln" ) { SupportsTestCoverage = true, CanFormatCode = true } },

--- a/eng/src/Program.cs
+++ b/eng/src/Program.cs
@@ -14,8 +14,7 @@ var product = new Product( Dependencies.PostSharpEngineering )
         "PostSharp.Engineering.Sdk.$(PackageVersion).nupkg",
         "PostSharp.Engineering.BuildTools.$(PackageVersion).nupkg",
         "PostSharp.Engineering.BuildTools.AWS.$(PackageVersion).nupkg" ),
-    RequiresEngineeringSdk = false,
-    VcsProvider = VcsProvider.GitHub
+    RequiresEngineeringSdk = false
 };
 
 var commandApp = new CommandApp();

--- a/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
+++ b/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
@@ -139,7 +139,7 @@ namespace PostSharp.Engineering.BuildTools
                                 "bump",
                                 bump => bump.AddCommand<BumpCommand>( "version" )
                                     .WithData( product )
-                                    .WithDescription( "Bumps the version of this product." ) );
+                                    .WithDescription( "Bumps the version of this product" ) );
                         }
                     } );
             }

--- a/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
+++ b/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
@@ -135,7 +135,11 @@ namespace PostSharp.Engineering.BuildTools
 
                         if ( product.DependencyDefinition.IsVersioned )
                         {
-                            // TODO: add branch + command
+                            root.AddBranch(
+                                "bump",
+                                bump => bump.AddCommand<BumpCommand>( "version" )
+                                    .WithData( product )
+                                    .WithDescription( "Bumps the version of this product." ) );
                         }
                     } );
             }

--- a/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
+++ b/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
@@ -49,6 +49,13 @@ namespace PostSharp.Engineering.BuildTools
                             .WithData( product )
                             .WithDescription( "Swaps deployment slots" );
 
+                        if ( product.DependencyDefinition.IsVersioned )
+                        {
+                            root.AddCommand<BumpCommand>( "bump" )
+                                .WithData( product )
+                                .WithDescription( "Bumps the version of this product" );
+                        }
+
                         root.AddBranch(
                             "dependencies",
                             dependencies =>
@@ -132,13 +139,6 @@ namespace PostSharp.Engineering.BuildTools
                                     "xmldoc",
                                     xmldoc => xmldoc.AddCommand<RemoveInternalsCommand>( "clean" ).WithDescription( "Remove internals." ).WithData( product ) );
                             } );
-
-                        if ( product.DependencyDefinition.IsVersioned )
-                        {
-                            root.AddCommand<BumpCommand>( "bump" )
-                                .WithData( product )
-                                .WithDescription( "Bumps the version of this product" );
-                        }
                     } );
             }
         }

--- a/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
+++ b/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
@@ -135,11 +135,9 @@ namespace PostSharp.Engineering.BuildTools
 
                         if ( product.DependencyDefinition.IsVersioned )
                         {
-                            root.AddBranch(
-                                "bump",
-                                bump => bump.AddCommand<BumpCommand>( "version" )
-                                    .WithData( product )
-                                    .WithDescription( "Bumps the version of this product" ) );
+                            root.AddCommand<BumpCommand>( "bump" )
+                                .WithData( product )
+                                .WithDescription( "Bumps the version of this product" );
                         }
                     } );
             }

--- a/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
+++ b/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
@@ -132,6 +132,11 @@ namespace PostSharp.Engineering.BuildTools
                                     "xmldoc",
                                     xmldoc => xmldoc.AddCommand<RemoveInternalsCommand>( "clean" ).WithDescription( "Remove internals." ).WithData( product ) );
                             } );
+
+                        if ( product.DependencyDefinition.IsVersioned )
+                        {
+                            // TODO: add branch + command
+                        }
                     } );
             }
         }

--- a/src/PostSharp.Engineering.BuildTools/Build/BaseBuildSettings.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/BaseBuildSettings.cs
@@ -34,7 +34,7 @@ public class BaseBuildSettings : CommonCommandSettings
     [Obsolete( "Use the BuildConfiguration property." )]
     public BuildConfiguration ResolvedBuildConfiguration => this.BuildConfiguration;
 
-    [Description( "Simulate a continuous integration build by setting the build ContinuousIntegrationBuild properyt to TRUE." )]
+    [Description( "Simulate a continuous integration build by setting the build ContinuousIntegrationBuild property to TRUE." )]
     [CommandOption( "--ci" )]
     public bool ContinuousIntegration { get; set; }
 

--- a/src/PostSharp.Engineering.BuildTools/Build/BumpCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/BumpCommand.cs
@@ -1,0 +1,6 @@
+﻿namespace PostSharp.Engineering.BuildTools.Build;
+
+public class BumpCommand : BaseCommand<BaseBuildSettings>
+{
+    protected override bool ExecuteCore( BuildContext context, BaseBuildSettings settings ) => throw new System.NotImplementedException();
+}

--- a/src/PostSharp.Engineering.BuildTools/Build/BumpCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/BumpCommand.cs
@@ -1,8 +1,8 @@
 ﻿namespace PostSharp.Engineering.BuildTools.Build;
 
-public class BumpCommand : BaseCommand<BaseBuildSettings>
+public class BumpCommand : BaseCommand<BuildSettings>
 {
-    protected override bool ExecuteCore( BuildContext context, BaseBuildSettings settings )
+    protected override bool ExecuteCore( BuildContext context, BuildSettings settings )
     {
         return context.Product.BumpVersion( context, settings );
     }

--- a/src/PostSharp.Engineering.BuildTools/Build/BumpCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/BumpCommand.cs
@@ -2,5 +2,8 @@
 
 public class BumpCommand : BaseCommand<BaseBuildSettings>
 {
-    protected override bool ExecuteCore( BuildContext context, BaseBuildSettings settings ) => throw new System.NotImplementedException();
+    protected override bool ExecuteCore( BuildContext context, BaseBuildSettings settings )
+    {
+        return context.Product.BumpVersion( context, settings );
+    }
 }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1281,20 +1281,25 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
             if ( this.GetDependenciesVersions( context, versionsOverrideFile.Dependencies, out var versionsByDependency ) && directDependency != null )
             {
-                if ( !TryGetLastVersionTag( context, out var lastVersionTag ) )
-                {
-                    return false;
-                }
-
                 var buildServerDependencyVersion = versionsByDependency.SingleOrDefault( d => d.Key == directDependency.Name ).Value;
 
                 // If there are no changes since the last tag (i.e. last publishing) and the dependency version hasn't changed the bump will be skipped.
-                if ( !AreChangesSinceLastVersionTag( context, lastVersionTag ) || !this.IsDependencyVersionDifferent( context, directDependency, buildServerDependencyVersion ) )
+                if ( !this.IsDependencyVersionDifferent( context, directDependency, buildServerDependencyVersion ) )
                 {
-                    context.Console.WriteWarning( "Skipping version bump as there are no changes since the last version tag." );
-
                     return true;
                 }
+            }
+
+            if ( !TryGetLastVersionTag( context, out var lastVersionTag ) )
+            {
+                return false;
+            }
+
+            if ( !AreChangesSinceLastVersionTag( context, lastVersionTag ) )
+            {
+                context.Console.WriteWarning( "Skipping version bump as there are no changes since the last version tag." );
+
+                return true;
             }
 
             this.TryLoadMainVersion( context, mainVersionFile, out var mainVersionInfo );

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1781,10 +1781,20 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             var versionNumbers = new List<string>();
 
             // For each stored version file we add the version number to list.
-            foreach ( var file in versionFiles )
+            foreach ( var dependencySources in dependencies.Values )
             {
+                var file = dependencySources.VersionFile;
+
                 if ( file == null )
                 {
+                    var versionNumber = dependencySources.Version;
+
+                    if ( versionNumber != null )
+                    {
+                        // For comparison below we need only numeric part of the version number.
+                        versionNumbers.Add( versionNumber.Substring( 0, versionNumber.IndexOf( '-', StringComparison.InvariantCulture ) ) );
+                    }
+
                     continue;
                 }
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1313,7 +1313,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                         buildAgentType: this.BuildAgentType )
                     {
                         IsDeployment = true,
-                        ArtifactDependencies = new[] { (buildTeamCityConfiguration.ObjectName, artifactRules) }
+                        ArtifactDependencies = new[] { (buildTeamCityConfiguration.ObjectName, artifactRules) },
+                        BuildTriggers = this.DependencyDefinition.IsVersioned ? new IBuildTrigger[] { new VersionBumpTrigger( this.DependencyDefinition ) } : null
                     };
 
                     teamCityBuildConfigurations.Add( teamCityDeploymentConfiguration );
@@ -1656,7 +1657,9 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         public bool BumpVersion( BuildContext context, BaseBuildSettings settings )
         {
             // TODO: call TryBumpVersion
+            return true;
         }
+
         private bool TryBumpVersion(
             BuildContext context,
             string mainVersionFile,

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1286,7 +1286,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 // If there are no changes since the last tag (i.e. last publishing) and the dependency version hasn't changed the bump will be skipped.
                 if ( !this.IsDependencyVersionDifferent( context, directDependency, buildServerDependencyVersion ) )
                 {
-                    Console.WriteLine( $"Skipping version bump as dependency '{directDependency.Name}' wasn't bumped recently." );
+                    context.Console.WriteWarning( $"Skipping version bump as dependency '{directDependency.Name}' wasn't bumped recently." );
                 }
             }
 
@@ -1299,7 +1299,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             {
                 context.Console.WriteWarning( "Skipping version bump as there are no changes since the last version tag." );
 
-                return true;
+                return false;
             }
 
             this.TryLoadMainVersion( context, mainVersionFile, out var mainVersionInfo );

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -671,7 +671,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             // Save BumpInfo.txt
             if ( !this.GetDependenciesVersions( context, versionsOverrideFile.Dependencies, out _ ) )
             {
-                context.Console.WriteImportantMessage( $"The product '{context.Product.ProductName}' doesn't have any dependencies to read versions from." );
+                context.Console.WriteWarning( $"The product '{context.Product.ProductName}' doesn't have any dependencies to read versions from, BumpInfo file was not created." );
             }
 
             // We always save the Versions.g.props because it may not exist and it may have been changed by the previous step.
@@ -1286,7 +1286,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 // If there are no changes since the last tag (i.e. last publishing) and the dependency version hasn't changed the bump will be skipped.
                 if ( !this.IsDependencyVersionDifferent( context, directDependency, buildServerDependencyVersion ) )
                 {
-                    return true;
+                    Console.WriteLine( $"Skipping version bump as dependency '{directDependency.Name}' wasn't bumped recently." );
                 }
             }
 
@@ -1525,8 +1525,6 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
                 return true;
             }
-
-            Console.WriteLine( $"Skipping version bump as dependency '{dependency.Key}' wasn't bumped recently." );
 
             return false;
         }
@@ -1780,7 +1778,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             var versionFiles = dependencies.Values.Select( d => d.VersionFile );
             var versionNumbers = new List<string>();
 
-            // For each stored version file we add the version number to list.
+            // For each stored dependency we add the version number to list.
             foreach ( var dependencySources in dependencies.Values )
             {
                 var file = dependencySources.VersionFile;

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1766,7 +1766,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             versionsByDependency = null;
 
             // If project doesn't have any dependency other than PostSharp.Engineering, reading version files is skipped.
-            if ( dependencies.All( d => d.Key == "PostSharp.Engineering" ) )
+            if ( dependencies.Count == 0 )
             {
                 return false;
             }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1273,6 +1273,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 return false;
             }
 
+            context.Console.WriteHeading( $"Bumping the '{context.Product.ProductName}' version." );
+
             if ( !this.TryBumpVersion( context, settings, mainVersionFile, mainVersionInfo ) )
             {
                 return false;
@@ -1370,6 +1372,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                         buildArguments: $"bump version",
                         buildAgentType: this.BuildAgentType )
                     {
+                        IsDeployment = true,
                         BuildTriggers = this.DependencyDefinition.IsVersioned ? new IBuildTrigger[] { new VersionBumpTrigger( this.DependencyDefinition ) } : null
                     } );
             }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1307,7 +1307,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             return success;
         }
 
-        public bool BumpVersion( BuildContext context, BaseBuildSettings settings )
+        public bool BumpVersion( BuildContext context, BuildSettings settings )
         {
             // When bumping locally, the product with MainVersionDependency is not allowed to be manually bumped.
             if ( this.MainVersionDependency != null )
@@ -1330,18 +1330,17 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 return false;
             }
 
-            // Load Versions.props but not Versions.Debug.g.props. We need a mutable DependenciesOverrideFile file for use with FetchDependencies.
-            if ( !DependenciesOverrideFile.TryLoadDefaultsOnly( context, BuildConfiguration.Public, out var dependenciesOverrideFile ) )
+            // Dependencies versions to compare with BumpInfo file are from Public build.
+            settings.BuildConfiguration = BuildConfiguration.Public;
+
+            // Do prepare step to get Version.Public.g.props.
+            if ( !this.Prepare( context, settings ) )
             {
                 return false;
             }
 
-            // Fetch the latest dependencies, even if we have fetched before in a local build.
-            if ( !FetchDependencyCommand.FetchDependencies(
-                    context,
-                    BuildConfiguration.Public,
-                    dependenciesOverrideFile,
-                    new FetchDependenciesCommandSettings() { Update = true } ) )
+            // Get dependenciesOverrideFile from Versions.Public.g.props.
+            if ( !DependenciesOverrideFile.TryLoadDefaultsOnly( context, settings.BuildConfiguration, out var dependenciesOverrideFile ) )
             {
                 return false;
             }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1367,7 +1367,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                         this,
                         objectName: "VersionBump",
                         name: $"Version Bump",
-                        buildArguments: $"--version bump",
+                        buildArguments: $"bump version",
                         buildAgentType: this.BuildAgentType )
                     {
                         BuildTriggers = this.DependencyDefinition.IsVersioned ? new IBuildTrigger[] { new VersionBumpTrigger( this.DependencyDefinition ) } : null

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
@@ -89,14 +89,14 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         }}" );
 
             var productVcsProvider = this.Product.VcsProvider;
-            
-            // The SSH agent is added only for the Deployment and only if TeamCity uses SSH for Git operations over the VCS repository.
+
+            // The SSH agent is added only for the Deployment and only if TeamCity uses SSH for Git operations over the product VCS repository.
             if ( productVcsProvider != null && this.IsDeployment && productVcsProvider.SshAgentRequired )
             {
                 writer.WriteLine(
                     $@"        sshAgent {{
             // By convention, the SSH key name is always PostSharp.Engineering for all repositories using SSH to connect.
-            teamcitySshKey = ""{this.Product.ProductName}""
+            teamcitySshKey = ""PostSharp.Engineering""
         }}" );
             }
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
@@ -90,12 +90,12 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
             var productVcsProvider = this.Product.VcsProvider;
             
-            // The SSH agent is added only for the Deployment and only if TeamCity needs it to use Git operations on the VCS repository.
+            // The SSH agent is added only for the Deployment and only if TeamCity uses SSH for Git operations over the VCS repository.
             if ( productVcsProvider != null && this.IsDeployment && productVcsProvider.SshAgentRequired )
             {
                 writer.WriteLine(
                     $@"        sshAgent {{
-            // By convention, the SSH key name is the same as the product name.
+            // By convention, the SSH key name is always PostSharp.Engineering for all repositories using SSH to connect.
             teamcitySshKey = ""{this.Product.ProductName}""
         }}" );
             }

--- a/src/PostSharp.Engineering.BuildTools/Build/Triggers/VersionBumpTrigger.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Triggers/VersionBumpTrigger.cs
@@ -9,24 +9,27 @@ namespace PostSharp.Engineering.BuildTools.Build.Triggers;
 /// </summary>
 public class VersionBumpTrigger : IBuildTrigger
 {
-    public VersionBumpTrigger( DependencyDefinition dependencyDefinition )
+    public VersionBumpTrigger( DependencyDefinition? dependencyDefinition )
     {
         this.DependencyDefinition = dependencyDefinition;
     }
 
-    public DependencyDefinition DependencyDefinition { get; }
+    public DependencyDefinition? DependencyDefinition { get; }
 
     public bool SuccessfulOnly { get; set; } = true;
 
     public void GenerateTeamcityCode( TextWriter writer )
     {
-        writer.WriteLine(
-            $@"
+        if ( this.DependencyDefinition != null )
+        {
+            writer.WriteLine(
+                $@"
         finishBuildTrigger {{
-            buildType = ""{this.DependencyDefinition.VcsProjectName}_{this.DependencyDefinition.NameWithoutDot}_PublicDeployment""
-            // Only successful deployment will trigger the version bump.
+            buildType = ""{this.DependencyDefinition.BumpBuildType}""
+            // Only successful dependency version bump will trigger version bump of this product.
             successfulOnly = {this.SuccessfulOnly.ToString().ToLowerInvariant()}
             branchFilter = ""+:<default>""
         }}        " );
+        }
     }
 }

--- a/src/PostSharp.Engineering.BuildTools/Build/Triggers/VersionBumpTrigger.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Triggers/VersionBumpTrigger.cs
@@ -23,9 +23,9 @@ public class VersionBumpTrigger : IBuildTrigger
         writer.WriteLine(
             $@"
         finishBuildTrigger {{
-            buildType = ""{this.DependencyDefinition.VcsProjectName}_{this.DependencyDefinition.NameWithoutDot}_Bump""
-            // Only successful build will trigger version bump.
-            watchChangesInDependencies = {this.SuccessfulOnly.ToString().ToLowerInvariant()}
+            buildType = ""{this.DependencyDefinition.VcsProjectName}_{this.DependencyDefinition.NameWithoutDot}_PublicDeployment""
+            // Only successful deployment will trigger the version bump.
+            successfulOnly = {this.SuccessfulOnly.ToString().ToLowerInvariant()}
             branchFilter = ""+:<default>""
         }}        " );
     }

--- a/src/PostSharp.Engineering.BuildTools/Build/Triggers/VersionBumpTrigger.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Triggers/VersionBumpTrigger.cs
@@ -5,7 +5,7 @@ using System.IO;
 namespace PostSharp.Engineering.BuildTools.Build.Triggers;
 
 /// <summary>
-/// Generates a build trigger that triggers the build when the source code has changed in the default branch.
+/// Generates a build trigger that triggers this product's version bump when the dependency product's version has been successfully bumped.
 /// </summary>
 public class VersionBumpTrigger : IBuildTrigger
 {

--- a/src/PostSharp.Engineering.BuildTools/Build/Triggers/VersionBumpTrigger.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Triggers/VersionBumpTrigger.cs
@@ -1,0 +1,32 @@
+﻿using PostSharp.Engineering.BuildTools.Build.Model;
+using PostSharp.Engineering.BuildTools.Dependencies.Model;
+using System.IO;
+
+namespace PostSharp.Engineering.BuildTools.Build.Triggers;
+
+/// <summary>
+/// Generates a build trigger that triggers the build when the source code has changed in the default branch.
+/// </summary>
+public class VersionBumpTrigger : IBuildTrigger
+{
+    public VersionBumpTrigger( DependencyDefinition dependencyDefinition )
+    {
+        this.DependencyDefinition = dependencyDefinition;
+    }
+
+    public DependencyDefinition DependencyDefinition { get; }
+
+    public bool SuccessfulOnly { get; set; } = true;
+
+    public void GenerateTeamcityCode( TextWriter writer )
+    {
+        writer.WriteLine(
+            $@"
+        finishBuildTrigger {{
+            buildType = ""{this.DependencyDefinition.VcsProjectName}_{this.DependencyDefinition.NameWithoutDot}_Bump""
+            // Only successful build will trigger version bump.
+            watchChangesInDependencies = {this.SuccessfulOnly.ToString().ToLowerInvariant()}
+            branchFilter = ""+:<default>""
+        }}        " );
+    }
+}

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/ConfigureDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/ConfigureDependenciesCommand.cs
@@ -37,7 +37,7 @@ public abstract class ConfigureDependenciesCommand<T> : BaseCommand<T>
         }
 
         // Loads the current version file.
-        if ( !VersionsOverrideFile.TryLoad( context, configuration, out var versionsOverrideFile ) )
+        if ( !DependenciesOverrideFile.TryLoad( context, configuration, out var dependenciesOverrideFile ) )
         {
             return false;
         }
@@ -77,7 +77,7 @@ public abstract class ConfigureDependenciesCommand<T> : BaseCommand<T>
             }
 
             // Executes the logic itself.
-            if ( !this.ConfigureDependency( context, versionsOverrideFile, dependencyDefinition, settings ) )
+            if ( !this.ConfigureDependency( context, dependenciesOverrideFile, dependencyDefinition, settings ) )
             {
                 return false;
             }
@@ -86,22 +86,22 @@ public abstract class ConfigureDependenciesCommand<T> : BaseCommand<T>
         // Fetching dependencies.
         context.Console.WriteImportantMessage( "Fetching dependencies" );
 
-        if ( !FetchDependencyCommand.FetchDependencies( context, configuration, versionsOverrideFile ) )
+        if ( !FetchDependencyCommand.FetchDependencies( context, configuration, dependenciesOverrideFile ) )
         {
             return false;
         }
 
         // Writing the version file.
-        context.Console.WriteImportantMessage( $"Writing '{versionsOverrideFile.FilePath}'" );
+        context.Console.WriteImportantMessage( $"Writing '{dependenciesOverrideFile.FilePath}'" );
 
-        if ( !versionsOverrideFile.TrySave( context ) )
+        if ( !dependenciesOverrideFile.TrySave( context ) )
         {
             return false;
         }
 
         context.Console.Out.WriteLine();
 
-        versionsOverrideFile.Print( context );
+        dependenciesOverrideFile.Print( context );
 
         context.Console.WriteSuccess( "Setting dependencies was successful." );
 
@@ -110,7 +110,7 @@ public abstract class ConfigureDependenciesCommand<T> : BaseCommand<T>
 
     protected abstract bool ConfigureDependency(
         BuildContext context,
-        VersionsOverrideFile versionsOverrideFile,
+        DependenciesOverrideFile dependenciesOverrideFile,
         DependencyDefinition dependencyDefinition,
         T settings );
 }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependencyCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependencyCommand.cs
@@ -172,7 +172,8 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
                     }
 
                     // Get the DependencyDefinition.
-                    var dependencyDefinition = Model.Dependencies.All.SingleOrDefault( d => d.Name == name );
+                    var dependencyDefinition = Model.Dependencies.All.SingleOrDefault( d => d.Name == name )
+                                               ?? TestDependencies.All.SingleOrDefault( d => d.Name == name );
 
                     if ( dependencyDefinition == null )
                     {

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependencyCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependencyCommand.cs
@@ -26,17 +26,17 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
                 return false;
             }
 
-            if ( !VersionsOverrideFile.TryLoad( context, configuration, out var versionsOverrideFile ) )
+            if ( !DependenciesOverrideFile.TryLoad( context, configuration, out var dependenciesOverrideFile ) )
             {
                 return false;
             }
 
-            if ( !FetchDependencies( context, configuration, versionsOverrideFile, settings ) )
+            if ( !FetchDependencies( context, configuration, dependenciesOverrideFile, settings ) )
             {
                 return false;
             }
 
-            if ( !versionsOverrideFile.TrySave( context ) )
+            if ( !dependenciesOverrideFile.TrySave( context ) )
             {
                 return false;
             }
@@ -47,7 +47,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
         public static bool FetchDependencies(
             BuildContext context,
             BuildConfiguration configuration,
-            VersionsOverrideFile versionsOverrideFile,
+            DependenciesOverrideFile dependenciesOverrideFile,
             FetchDependenciesCommandSettings? settings = null )
         {
             settings ??= new FetchDependenciesCommandSettings();
@@ -64,7 +64,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
                 return dependencyDefinition;
             }
 
-            var dependencies = versionsOverrideFile
+            var dependencies = dependenciesOverrideFile
                 .Dependencies
                 .Where( d => d.Value.Origin != DependencyConfigurationOrigin.Transitive )
                 .Select( d => (d.Value, GetDependencyDefinition( d )) )
@@ -112,7 +112,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
                         context,
                         dependencyDictionary,
                         iterationDependencies,
-                        versionsOverrideFile,
+                        dependenciesOverrideFile,
                         out var newDependencies ) )
                 {
                     return false;
@@ -133,7 +133,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
             BuildContext context,
             ImmutableDictionary<string, Dependency> allDependencies,
             ImmutableArray<Dependency> directDependencies,
-            VersionsOverrideFile versionsOverrideFile,
+            DependenciesOverrideFile dependenciesOverrideFile,
             out ImmutableArray<Dependency> newDependencies )
         {
             var newDependenciesBuilder = ImmutableArray.CreateBuilder<Dependency>();
@@ -231,7 +231,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
 
                     var newDependency = new Dependency( dependencySource, dependencyDefinition );
                     newDependenciesBuilder.Add( newDependency );
-                    versionsOverrideFile.Dependencies[name] = dependencySource;
+                    dependenciesOverrideFile.Dependencies[name] = dependencySource;
                 }
 
                 ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
@@ -374,7 +374,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
                             dependency.Definition.Name,
                             dependency.Definition.Name + ".Import.props" ) );
                 }
-                
+
                 if ( !File.Exists( dependency.Source.VersionFile ) )
                 {
                     context.Console.WriteError( $"The file '{dependency.Source.VersionFile}' does not exist. Check that the product has been built." );

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/ListDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/ListDependenciesCommand.cs
@@ -25,12 +25,12 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
                     return false;
                 }
 
-                if ( !VersionsOverrideFile.TryLoad( context, configuration, out var versionsOverrideFile ) )
+                if ( !DependenciesOverrideFile.TryLoad( context, configuration, out var dependenciesOverrideFile ) )
                 {
                     return false;
                 }
 
-                versionsOverrideFile.Print( context );
+                dependenciesOverrideFile.Print( context );
             }
 
             return true;

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
@@ -13,17 +13,17 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
         public static DependencyDefinition MetalamaCompiler { get; } = new(
             "Metalama.Compiler",
             VcsProvider.AzureRepos,
-            "Metalama",
-
+            "Metalama" )
+        {
             // The release build is intentionally used for the debug configuration because we want dependencies to consume the release
             // build, for performance reasons. The debug build will be used only locally, and for this we don't need a configuration here.
-            ("Metalama_MetalamaCompiler_ReleaseBuild", "Metalama_MetalamaCompiler_ReleaseBuild", "Metalama_MetalamaCompiler_PublicBuild") );
+            CiBuildTypes = new( "Metalama_MetalamaCompiler_ReleaseBuild", "Metalama_MetalamaCompiler_ReleaseBuild", "Metalama_MetalamaCompiler_PublicBuild" )
+        };
 
         public static DependencyDefinition Metalama { get; } = new(
             "Metalama",
             VcsProvider.AzureRepos,
-            "Metalama",
-            ("Metalama_Metalama_DebugBuild", "Metalama_Metalama_ReleaseBuild", "Metalama_Metalama_PublicBuild") );
+            "Metalama");
 
         public static DependencyDefinition MetalamaSamples { get; } = new( "Metalama.Samples", VcsProvider.GitHub, "postsharp" );
 
@@ -34,24 +34,24 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
         public static DependencyDefinition PostSharpEngineering { get; } = new(
             "PostSharp.Engineering",
             VcsProvider.GitHub,
-            "postsharp",
+            "postsharp" )
+        {
+            GenerateSnapshotDependency = false,
 
             // We always use the debug build for engineering.
-            ("PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild") ) { GenerateSnapshotDependency = false };
+            CiBuildTypes= new( "PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild" )
+        };
 
         [Obsolete( "Renamed to MetalamaBackstage" )]
         public static DependencyDefinition PostSharpBackstageSettings { get; } = new(
             "PostSharp.Backstage.Settings",
             VcsProvider.AzureRepos,
-            "Metalama",
-            ("Metalama_PostSharpBackstageSettings_DebugBuild", "Metalama_PostSharpBackstageSettings_ReleaseBuild",
-             "Metalama_PostSharpBackstageSettings_PublicBuild") );
+            "Metalama" );
 
         public static DependencyDefinition MetalamaBackstage { get; } = new(
             "Metalama.Backstage",
             VcsProvider.AzureRepos,
-            "Metalama",
-            ("Metalama_MetalamaBackstage_DebugBuild", "Metalama_MetalamaBackstage_ReleaseBuild", "Metalama_MetalamaBackstage_PublicBuild") );
+            "Metalama" );
 
         public static ImmutableArray<DependencyDefinition> All { get; } = ImmutableArray.Create(
             Roslyn,

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
@@ -5,11 +5,6 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
 {
     public static class Dependencies
     {
-        public static DependencyDefinition Roslyn { get; } = new(
-            "Roslyn",
-            VcsProvider.None,
-            "Roslyn" );
-
         public static DependencyDefinition MetalamaCompiler { get; } = new(
             "Metalama.Compiler",
             VcsProvider.AzureRepos,
@@ -17,7 +12,10 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
         {
             // The release build is intentionally used for the debug configuration because we want dependencies to consume the release
             // build, for performance reasons. The debug build will be used only locally, and for this we don't need a configuration here.
-            CiBuildTypes = new( "Metalama_MetalamaCompiler_ReleaseBuild", "Metalama_MetalamaCompiler_ReleaseBuild", "Metalama_MetalamaCompiler_PublicBuild" )
+            CiBuildTypes = new ConfigurationSpecific<string>(
+                "Metalama_MetalamaCompiler_ReleaseBuild",
+                "Metalama_MetalamaCompiler_ReleaseBuild",
+                "Metalama_MetalamaCompiler_PublicBuild" )
         };
 
         public static DependencyDefinition Metalama { get; } = new(
@@ -39,7 +37,10 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             GenerateSnapshotDependency = false,
 
             // We always use the debug build for engineering.
-            CiBuildTypes = new( "PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild" )
+            CiBuildTypes = new ConfigurationSpecific<string>(
+                "PostSharpEngineering_DebugBuild",
+                "PostSharpEngineering_DebugBuild",
+                "PostSharpEngineering_DebugBuild" )
         };
 
         [Obsolete( "Renamed to MetalamaBackstage" )]
@@ -54,7 +55,6 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             "Metalama" );
 
         public static ImmutableArray<DependencyDefinition> All { get; } = ImmutableArray.Create(
-            Roslyn,
             MetalamaCompiler,
             Metalama,
             MetalamaDocumentation,

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
@@ -23,7 +23,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
         public static DependencyDefinition Metalama { get; } = new(
             "Metalama",
             VcsProvider.AzureRepos,
-            "Metalama");
+            "Metalama" );
 
         public static DependencyDefinition MetalamaSamples { get; } = new( "Metalama.Samples", VcsProvider.GitHub, "postsharp" );
 
@@ -39,7 +39,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             GenerateSnapshotDependency = false,
 
             // We always use the debug build for engineering.
-            CiBuildTypes= new( "PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild" )
+            CiBuildTypes = new( "PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild", "PostSharpEngineering_DebugBuild" )
         };
 
         [Obsolete( "Renamed to MetalamaBackstage" )]

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/DependencyDefinition.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/DependencyDefinition.cs
@@ -10,9 +10,13 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
 
         public string RepoName { get; init; }
 
-        public string DefaultBranch { get; }
+        public string DefaultBranch { get; init; }
 
-        public ConfigurationSpecific<string> CiBuildTypes { get; }
+        public ConfigurationSpecific<string> CiBuildTypes { get; init; }
+        
+        public bool IsVersioned { get; }
+        
+        public string? BumpBuildType { get; init; }
 
         public string VcsProjectName { get; }
 
@@ -24,30 +28,22 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
         /// Initializes a new instance of the <see cref="DependencyDefinition"/> class that represents an external dependency, i.e. one
         /// that we do not build ourselves.
         /// </summary>
-        public DependencyDefinition( string name, VcsProvider provider, string vcsProjectName )
+        public DependencyDefinition( string name, VcsProvider provider, string vcsProjectName, bool isVersioned = true )
         {
             this.Name = name;
             this.Provider = provider;
             this.VcsProjectName = vcsProjectName;
             this.RepoName = name;
             this.DefaultBranch = "master";
-            this.CiBuildTypes = new ConfigurationSpecific<string>( "N/A", "N/A", "N/A" );
+            this.IsVersioned = isVersioned;
+            this.CiBuildTypes = new ConfigurationSpecific<string>( $"{this.VcsProjectName}_{this.NameWithoutDot}_DebugBuild", $"{this.VcsProjectName}_{this.NameWithoutDot}ReleaseBuild", $"{this.VcsProjectName}_{this.NameWithoutDot}_PublicBuild" );
+
+            if ( this.IsVersioned )
+            {
+                this.BumpBuildType = $"{this.VcsProjectName}_{this.NameWithoutDot}_Bump";
+            }
         }
 
-        public DependencyDefinition(
-            string name,
-            VcsProvider provider,
-            string vcsProjectName,
-            in (string Debug, string Release, string Public) ciBuildTypes,
-            string defaultBranch = "master" )
-        {
-            this.Name = name;
-            this.Provider = provider;
-            this.VcsProjectName = vcsProjectName;
-            this.RepoName = name;
-            this.DefaultBranch = defaultBranch;
-            this.CiBuildTypes = new ConfigurationSpecific<string>( ciBuildTypes );
-        }
 
         public override string ToString() => this.Name;
     }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/DependencyDefinition.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/DependencyDefinition.cs
@@ -44,7 +44,6 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             }
         }
 
-
         public override string ToString() => this.Name;
     }
 }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/DependencyDefinition.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/DependencyDefinition.cs
@@ -36,11 +36,15 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             this.RepoName = name;
             this.DefaultBranch = "master";
             this.IsVersioned = isVersioned;
-            this.CiBuildTypes = new ConfigurationSpecific<string>( $"{this.VcsProjectName}_{this.NameWithoutDot}_DebugBuild", $"{this.VcsProjectName}_{this.NameWithoutDot}ReleaseBuild", $"{this.VcsProjectName}_{this.NameWithoutDot}_PublicBuild" );
+
+            this.CiBuildTypes = new ConfigurationSpecific<string>(
+                $"{this.VcsProjectName}_{this.NameWithoutDot}_DebugBuild",
+                $"{this.VcsProjectName}_{this.NameWithoutDot}_ReleaseBuild",
+                $"{this.VcsProjectName}_{this.NameWithoutDot}_PublicBuild" );
 
             if ( this.IsVersioned )
             {
-                this.BumpBuildType = $"{this.VcsProjectName}_{this.NameWithoutDot}_Bump";
+                this.BumpBuildType = $"{this.VcsProjectName}_{this.NameWithoutDot}_VersionBump";
             }
         }
 

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/TestDependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/TestDependencies.cs
@@ -12,7 +12,7 @@ public static class TestDependencies
     public static DependencyDefinition Dependency { get; } = new(
         "PostSharp.Engineering.Test.Dependency",
         VcsProvider.AzureRepos,
-        "Test");
+        "Test" );
     
     public static DependencyDefinition TransitiveDependency { get; } = new(
         "PostSharp.Engineering.Test.TransitiveDependency",
@@ -22,12 +22,12 @@ public static class TestDependencies
     public static DependencyDefinition GitHub { get; } = new(
         "PostSharp.Engineering.Test.GitHub",
         VcsProvider.GitHub,
-        "Test");
+        "Test" );
     
     public static DependencyDefinition MainVersionDependency { get; } = new(
         "PostSharp.Engineering.Test.MainVersionDependency",
         VcsProvider.AzureRepos,
-        "Test");
+        "Test" );
     
     public static DependencyDefinition PatchVersion { get; } = new(
         "PostSharp.Engineering.Test.PatchVersion",

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/TestDependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/TestDependencies.cs
@@ -7,38 +7,32 @@ public static class TestDependencies
     public static DependencyDefinition TestProduct { get; } = new(
         "PostSharp.Engineering.Test.TestProduct",
         VcsProvider.AzureRepos,
-        "postsharp",
-        ("Test_PostSharpEngineeringTestProduct_DebugBuild", "Test_PostSharpEngineeringTestProduct_ReleaseBuild", "Test_PostSharpEngineeringTestProduct_PublicBuild") );
+        "Test" );
     
     public static DependencyDefinition Dependency { get; } = new(
         "PostSharp.Engineering.Test.Dependency",
         VcsProvider.AzureRepos,
-        "postsharp",
-        ("Test_PostSharpEngineeringTestDependency_DebugBuild", "Test_PostSharpEngineeringTestDependency_ReleaseBuild", "Test_PostSharpEngineeringTestDependency_PublicBuild") );
+        "Test");
     
     public static DependencyDefinition TransitiveDependency { get; } = new(
         "PostSharp.Engineering.Test.TransitiveDependency",
         VcsProvider.AzureRepos,
-        "postsharp",
-        ("Test_PostSharpEngineeringTestTransitiveDependency_DebugBuild", "Test_PostSharpEngineeringTestTransitiveDependency_ReleaseBuild", "Test_PostSharpEngineeringTestTransitiveDependency_PublicBuild") );
+        "Test" );
 
     public static DependencyDefinition GitHub { get; } = new(
         "PostSharp.Engineering.Test.GitHub",
         VcsProvider.GitHub,
-        "postsharp",
-        ("Test_PostSharpEngineeringTestGitHub_DebugBuild", "Test_PostSharpEngineeringTestGitHub_ReleaseBuild", "Test_PostSharpEngineeringTestGitHub_PublicBuild") );
+        "Test");
     
     public static DependencyDefinition MainVersionDependency { get; } = new(
         "PostSharp.Engineering.Test.MainVersionDependency",
         VcsProvider.AzureRepos,
-        "postsharp",
-        ("Test_PostSharpEngineeringTestMainVersionDependency_DebugBuild", "Test_PostSharpEngineeringTestMainVersionDependency_ReleaseBuild", "Test_PostSharpEngineeringTestMainVersionDependency_PublicBuild") );
+        "Test");
     
     public static DependencyDefinition PatchVersion { get; } = new(
         "PostSharp.Engineering.Test.PatchVersion",
         VcsProvider.AzureRepos,
-        "postsharp",
-        ("Test_PostSharpEngineeringTestPatchVersion_DebugBuild", "Test_PostSharpEngineeringTestPatchVersion_ReleaseBuild", "Test_PostSharpEngineeringTestPatchVersion_PublicBuild") );
+        "Test" );
 
     public static ImmutableArray<DependencyDefinition> All { get; } = ImmutableArray.Create(
         TestProduct,

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/VersionFile.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/VersionFile.cs
@@ -1,0 +1,173 @@
+﻿using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using PostSharp.Engineering.BuildTools.Build;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace PostSharp.Engineering.BuildTools.Dependencies.Model;
+
+/// <summary>
+/// Represents then information of <c>Versions.props</c>.
+/// </summary>
+public class VersionFile
+{
+    private static readonly Regex _dependencyVersionRegex = new(
+        "^(?<Kind>[^:]+):(?<Arguments>.+)$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant );
+
+    private static readonly Regex _buildSettingsRegex = new(
+        @"^Number=(?<Number>\d+)(;TypeId=(?<TypeId>[^;]+))?(;TypeId=(?<Branch>[^;]+))?$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant );
+
+    private VersionFile( ImmutableDictionary<string, DependencySource> dependencies )
+    {
+        this.Dependencies = dependencies;
+    }
+
+    public ImmutableDictionary<string, DependencySource> Dependencies { get; }
+
+    public static bool TryRead( BuildContext context, [NotNullWhen( true )] out VersionFile? versionFile )
+    {
+        var dependenciesBuilder = ImmutableDictionary.CreateBuilder<string, DependencySource>();
+
+        var versionsPath = Path.Combine( context.RepoDirectory, context.Product.VersionsFilePath );
+
+        if ( !File.Exists( versionsPath ) )
+        {
+            context.Console.WriteError( $"The file '{versionsPath}' does not exist." );
+
+            versionFile = null;
+
+            return false;
+        }
+
+        var projectOptions = new ProjectOptions { GlobalProperties = new Dictionary<string, string>() { ["VcsBranch"] = context.Branch } };
+        var projectFile = Project.FromFile( versionsPath, projectOptions );
+
+        var defaultDependencyProperties = context.Product.Dependencies
+            .ToDictionary(
+                d => d.Name,
+                d => projectFile.Properties.SingleOrDefault( p => p.Name == d.NameWithoutDot + "Version" )
+                    ?.EvaluatedValue );
+
+        ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
+
+        foreach ( var dependencyDefinition in context.Product.Dependencies )
+        {
+            var dependencyVersion = defaultDependencyProperties[dependencyDefinition.Name];
+
+            if ( string.IsNullOrEmpty( dependencyVersion ) )
+            {
+                context.Console.WriteError( $"There is no {dependencyDefinition.NameWithoutDot}Version property in '{versionsPath}'." );
+
+                versionFile = null;
+
+                return false;
+            }
+
+            DependencySource dependencySource;
+
+            if ( string.Compare( dependencyVersion, "local", StringComparison.OrdinalIgnoreCase ) == 0 )
+            {
+                dependencySource = DependencySource.CreateLocal( DependencyConfigurationOrigin.Default );
+            }
+            else
+            {
+                var dependencyVersionMatch = _dependencyVersionRegex.Match( dependencyVersion );
+
+                if ( dependencyVersionMatch.Success )
+                {
+                    switch ( dependencyVersionMatch.Groups["Kind"].Value.ToLowerInvariant() )
+                    {
+                        case "branch":
+                            {
+                                var branch = dependencyVersionMatch.Groups["Arguments"].Value;
+
+                                dependencySource = DependencySource.CreateBuildServerSource(
+                                    new CiLatestBuildOfBranch( branch ),
+                                    DependencyConfigurationOrigin.Default );
+
+                                break;
+                            }
+
+                        case "build":
+                            {
+                                var arguments = dependencyVersionMatch.Groups["Arguments"].Value;
+
+                                var buildSettingsMatch = _buildSettingsRegex.Match( arguments );
+
+                                if ( !buildSettingsMatch.Success )
+                                {
+                                    context.Console.WriteError(
+                                        $"The TeamCity build configuration '{arguments}' of dependency '{dependencyDefinition.Name}' does not have a correct format." );
+
+                                    versionFile = null;
+
+                                    return false;
+                                }
+
+                                var buildNumber = int.Parse( buildSettingsMatch.Groups["Number"].Value, CultureInfo.InvariantCulture );
+                                var ciBuildTypeId = buildSettingsMatch.Groups.GetValueOrDefault( "TypeId" )?.Value;
+
+                                if ( string.IsNullOrEmpty( ciBuildTypeId ) )
+                                {
+                                    context.Console.WriteError(
+                                        $"The TypeId property of dependency '{dependencyDefinition.Name}' does is required in '{versionsPath}'." );
+                                }
+
+                                dependencySource = DependencySource.CreateBuildServerSource(
+                                    new CiBuildId( buildNumber, ciBuildTypeId ),
+                                    DependencyConfigurationOrigin.Default );
+
+                                break;
+                            }
+
+                        case "transitive":
+                            {
+                                context.Console.WriteError( $"Error in '{versionsPath}': explicit transitive dependencies are no longer supported." );
+
+                                versionFile = null;
+
+                                return false;
+                            }
+
+                        default:
+                            {
+                                context.Console.WriteError(
+                                    $"Error in '{versionsPath}': cannot parse the value '{dependencyVersion}' for dependency '{dependencyDefinition.Name}' in '{versionsPath}'." );
+
+                                versionFile = null;
+
+                                return false;
+                            }
+                    }
+                }
+                else if ( char.IsDigit( dependencyVersion[0] ) )
+                {
+                    dependencySource = DependencySource.CreateFeed( dependencyVersion, DependencyConfigurationOrigin.Default );
+                }
+                else
+                {
+                    context.Console.WriteError(
+                        $"Error in '{versionsPath}': cannot parse the dependency '{dependencyDefinition.Name}' from '{versionsPath}'." );
+
+                    versionFile = null;
+
+                    return false;
+                }
+            }
+
+            dependenciesBuilder[dependencyDefinition.Name] = dependencySource;
+        }
+
+        versionFile = new VersionFile( dependenciesBuilder.ToImmutable() );
+
+        return true;
+    }
+}

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/VersionsOverrideFile.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/VersionsOverrideFile.cs
@@ -367,7 +367,8 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
                     case DependencySourceKind.BuildServer:
                         {
                             var dependencyDefinition = context.Product.Dependencies.SingleOrDefault( p => p.Name == dependency.Key )
-                                                       ?? Model.Dependencies.All.SingleOrDefault( d => d.Name == dependency.Key );
+                                                       ?? Model.Dependencies.All.SingleOrDefault( d => d.Name == dependency.Key )
+                                                       ?? TestDependencies.All.SingleOrDefault( d => d.Name == dependency.Key );
 
                             if ( dependencyDefinition == null )
                             {

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/ResetDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/ResetDependenciesCommand.cs
@@ -10,11 +10,11 @@ public class ResetDependenciesCommand : ConfigureDependenciesCommand<ResetDepend
 {
     protected override bool ConfigureDependency(
         BuildContext context,
-        VersionsOverrideFile versionsOverrideFile,
+        DependenciesOverrideFile dependenciesOverrideFile,
         DependencyDefinition dependencyDefinition,
         ResetDependenciesCommandSettings settings )
     {
-        versionsOverrideFile.Dependencies.Remove( dependencyDefinition.Name );
+        dependenciesOverrideFile.Dependencies.Remove( dependencyDefinition.Name );
 
         return true;
     }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/SetDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/SetDependenciesCommand.cs
@@ -12,7 +12,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
     {
         protected override bool ConfigureDependency(
             BuildContext context,
-            VersionsOverrideFile versionsOverrideFile,
+            DependenciesOverrideFile dependenciesOverrideFile,
             DependencyDefinition dependencyDefinition,
             SetDependenciesCommandSettings settings )
         {
@@ -58,7 +58,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
                     throw new InvalidOperationException();
             }
 
-            versionsOverrideFile.Dependencies[dependencyDefinition.Name] = dependencySource;
+            dependenciesOverrideFile.Dependencies[dependencyDefinition.Name] = dependencySource;
 
             return true;
         }

--- a/src/PostSharp.Engineering.BuildTools/PostSharp.Engineering.BuildTools.csproj
+++ b/src/PostSharp.Engineering.BuildTools/PostSharp.Engineering.BuildTools.csproj
@@ -15,24 +15,24 @@
     <ItemGroup>
 
         <!-- Runtime assets excluded in favor of Microsoft.Build.Locator package. -->
-        <PackageReference Include="Microsoft.Build" Version="$(MSBuildPackagesVersion)" ExcludeAssets="runtime"/>
-        <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1"/>
+        <PackageReference Include="Microsoft.Build" Version="$(MSBuildPackagesVersion)" ExcludeAssets="runtime" />
+        <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
 
         <!-- Runtime assets excluded in favor of Microsoft.Build.Locator package. -->
-        <PackageReference Include="Microsoft.Build.Framework" Version="$(MSBuildPackagesVersion)" ExcludeAssets="runtime"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(RoslynVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.StringTools" Version="1.0.0"/>
-        <PackageReference Include="NuGet.Versioning" Version="5.8.1"/>
-        <PackageReference Include="Spectre.Console" Version="0.42.0"/>
-        <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0"/>
-        <PackageReference Include="System.Management" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Build.Framework" Version="$(MSBuildPackagesVersion)" ExcludeAssets="runtime" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(RoslynVersion)" />
+        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.StringTools" Version="1.0.0" />
+        <PackageReference Include="NuGet.Versioning" Version="5.8.1" />
+        <PackageReference Include="Spectre.Console" Version="0.42.0" />
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+        <PackageReference Include="System.Management" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <EmbeddedResource Include="ToolsResources\*.*"/>
+        <EmbeddedResource Include="ToolsResources\*.*" />
     </ItemGroup>
 
 

--- a/src/PostSharp.Engineering.BuildTools/Utilities/TeamcityClient.cs
+++ b/src/PostSharp.Engineering.BuildTools/Utilities/TeamcityClient.cs
@@ -92,6 +92,22 @@ namespace PostSharp.Engineering.BuildTools.Utilities
             zip.ExtractToDirectory( directory, true );
         }
 
+        public void DownloadSingleArtifact( string buildTypeId, int buildNumber, string artifactPath, string saveLocation, CancellationToken cancellationToken )
+        {
+            var url = $"https://tc.postsharp.net/repository/download/{buildTypeId}/{buildNumber}/{artifactPath}";
+            var httpResponse = this._httpClient.GetAsync( url, cancellationToken ).Result;
+
+            using ( var stream = httpResponse.Content.ReadAsStreamAsync( cancellationToken ).Result )
+            {
+                var fileInfo = new FileInfo( saveLocation );
+
+                using ( var fileStream = fileInfo.OpenWrite() )
+                {
+                    stream.CopyToAsync( fileStream, cancellationToken );
+                }
+            }
+        }
+
         public void Dispose()
         {
             this._httpClient.Dispose();


### PR DESCRIPTION
**Current state of version bump:**


0. Each Product now needs to have BumpInfo.txt in its 'eng' directory, unless Product is PostSharp.Engineering (= has no dependencies). The first time versions should need to be set only once and whenver there is a VersionBump, it would get updated.

1. Each TeamCity project that deals with versioning and needs bumping will have its own VersionBump TC build configuration.
- 1.1 If there is a dependency between A and B, where 'A has B as a dependency', whenever B is version bumped manually, A's versionbump will also get triggered automatically. This is to ensure cascade of bumps.

2. Added 'b bump version' command, it is used by TC build config mentioned in 1.

3. If there is any other dependency other than PostSharp.Engineering, we gather dependencies versions and compare those with locally saved versions in BumpInfo.txt.
- 3.1 If there is a difference (or change in current Product) the VersionBump can proceed.
- 3.2 If there is no difference or no change, it fails.
- 3.3 Only PostSharp.Engineering as dependency also checks for Product changes before proceeding with VersionBump.

**Note:** Currently we assume only one Direct Dependency of a product exists and only that one is compared for difference in versions.

4. After successful Version Bump the BumpInfo.txt is updated with newest versions.