### PR TITLE
#30339 Added fetching for tags, removed Publishing checks.

### DIFF
--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1186,17 +1186,19 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                     return false;
                 }
 
-                // If there are no changes since the last tag (i.e. last publishing), we get a warning about publishing the same version.
+                // If there are no changes since the last tag (i.e. last publishing), we get a warning about publishing the same version only.
                 if ( !AreChangesSinceLastVersionTag( context, lastVersionTag ) )
                 {
                     context.Console.WriteWarning(
                         $"There are no new unpublished changes since the last version tag '{lastVersionTag}'." );
                 }
-
-                // If version has not been bumped since the last publish, we get a warning about publishing the same version.
-                if ( !VersionHasBeenBumped( context, preparedVersionInfo.Version, lastVersionTag ) )
+                else
                 {
-                    return false;
+                    // If there are changes and the version has not been bumped since the last publish, publishing fails.
+                    if ( !VersionHasBeenBumped( context, preparedVersionInfo.Version, lastVersionTag ) )
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1240,7 +1240,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 if ( !AddTagToLastCommit( context, preparedVersionInfo, settings ) )
                 {
                     context.Console.WriteWarning(
-                        $"Could not tag the latest commit with version  '{preparedVersionInfo.Version}{preparedVersionInfo.PackageVersionSuffix}'." );
+                        $"Could not tag the latest commit with version '{preparedVersionInfo.Version}{preparedVersionInfo.PackageVersionSuffix}'." );
                 }
             }
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -690,7 +690,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
             if ( settings.BuildConfiguration == BuildConfiguration.Public && !TeamCityHelper.IsTeamCityBuild( settings ) && !settings.Force )
             {
-                context.Console.WriteError( "Cannot do a public build on a local machine without --force because it may corrupt the package cache." );
+                context.Console.WriteError( "Cannot prepare a public configuration on a local machine without --force because it may corrupt the package cache." );
 
                 return false;
             }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -688,6 +688,13 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
             context.Console.WriteHeading( "Preparing the version file" );
 
+            if ( settings.BuildConfiguration == BuildConfiguration.Public && !TeamCityHelper.IsTeamCityBuild( settings ) && !settings.Force )
+            {
+                context.Console.WriteError( "Cannot do a public build on a local machine without --force because it may corrupt the package cache." );
+
+                return false;
+            }
+
             var privateArtifactsRelativeDir =
                 this.PrivateArtifactsDirectory.ToString( new BuildInfo( null!, configuration, this ) );
 

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
@@ -34,13 +34,37 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
         public static DependencyDefinition MetalamaOpenAutoCancellationToken { get; } =
             new( "Metalama.Open.AutoCancellationToken", VcsProvider.GitHub, "Metalama" )
             {
-                // Metalama.Open.AutoCancellationToken is part of Metalama.Open products, which is propagated to build type string.
+                // Metalama.Open.AutoCancellationToken is part of Metalama.Open products group, which is propagated to build types string.
                 CiBuildTypes = new ConfigurationSpecific<string>(
                     "Metalama_MetalamaOpen_MetalamaOpenAutoCancellationToken_DebugBuild",
                     "Metalama_MetalamaOpen_MetalamaOpenAutoCancellationToken_ReleaseBuild",
                     "Metalama_MetalamaOpen_MetalamaOpenAutoCancellationToken_PublicBuild" ),
                 DeploymentBuildType = "Metalama_MetalamaOpen_MetalamaOpenAutoCancellationToken_PublicDeployment",
                 BumpBuildType = "Metalama_MetalamaOpen_MetalamaOpenAutoCancellationToken_VersionBump"
+            };
+
+        public static DependencyDefinition MetalamaOpenDependencyEmbedder { get; } =
+            new( "Metalama.Open.DependencyEmbedder", VcsProvider.GitHub, "Metalama" )
+            {
+                // Metalama.Open.DependencyEmbedder is part of Metalama.Open products group, which is propagated to build types string.
+                CiBuildTypes = new ConfigurationSpecific<string>(
+                    "Metalama_MetalamaOpen_MetalamaOpenDependencyEmbedder_DebugBuild",
+                    "Metalama_MetalamaOpen_MetalamaOpenDependencyEmbedder_ReleaseBuild",
+                    "Metalama_MetalamaOpen_MetalamaOpenDependencyEmbedder_PublicBuild" ),
+                DeploymentBuildType = "Metalama_MetalamaOpen_MetalamaOpenDependencyEmbedder_PublicDeployment",
+                BumpBuildType = "Metalama_MetalamaOpen_MetalamaOpenDependencyEmbedder_VersionBump"
+            };
+
+        public static DependencyDefinition MetalamaOpenVirtuosity { get; } =
+            new( "Metalama.Open.AutoCancellationToken", VcsProvider.GitHub, "Metalama" )
+            {
+                // Metalama.Open.Virtuosity is part of Metalama.Open products group, which is propagated to build types string.
+                CiBuildTypes = new ConfigurationSpecific<string>(
+                    "Metalama_MetalamaOpen_MetalamaOpenVirtuosity_DebugBuild",
+                    "Metalama_MetalamaOpen_MetalamaOpenVirtuosity_ReleaseBuild",
+                    "Metalama_MetalamaOpen_MetalamaOpenVirtuosity_PublicBuild" ),
+                DeploymentBuildType = "Metalama_MetalamaOpen_MetalamaOpenVirtuosity_PublicDeployment",
+                BumpBuildType = "Metalama_MetalamaOpen_MetalamaOpenVirtuosity_VersionBump"
             };
 
         public static DependencyDefinition PostSharpEngineering { get; } = new(
@@ -76,6 +100,8 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             MetalamaTry,
             MetalamaVsx,
             MetalamaOpenAutoCancellationToken,
+            MetalamaOpenDependencyEmbedder,
+            MetalamaOpenVirtuosity,
             PostSharpEngineering,
             MetalamaBackstage );
     }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
@@ -56,7 +56,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             };
 
         public static DependencyDefinition MetalamaOpenVirtuosity { get; } =
-            new( "Metalama.Open.AutoCancellationToken", VcsProvider.GitHub, "Metalama" )
+            new( "Metalama.Open.Virtuosity", VcsProvider.GitHub, "Metalama" )
             {
                 // Metalama.Open.Virtuosity is part of Metalama.Open products group, which is propagated to build types string.
                 CiBuildTypes = new ConfigurationSpecific<string>(

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/TestDependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/TestDependencies.cs
@@ -37,8 +37,16 @@ public static class TestDependencies
     public static DependencyDefinition NopCommerce { get; } = new(
         "Metalama.Tests.NopCommerce",
         VcsProvider.GitHub,
-        "Metalama",
-        false );
+        "postsharp",
+        false )
+    {
+        CiBuildTypes = new ConfigurationSpecific<string>(
+            "Metalama_MetalamaTests_MetalamaTestsNopCommerce_DebugBuild",
+            "Metalama_MetalamaTests_MetalamaTestsNopCommerce_ReleaseBuild",
+            "Metalama_MetalamaTests_MetalamaTestsNopCommerce_PublicBuild" ),
+        DeploymentBuildType = "Metalama_MetalamaTests_MetalamaTestsNopCommerce_PublicDeployment",
+        BumpBuildType = "Metalama_MetalamaTests_MetalamaTestsNopCommerce_VersionBump"
+    };
 
     public static ImmutableArray<DependencyDefinition> All { get; } = ImmutableArray.Create(
         TestProduct,


### PR DESCRIPTION
Changes summary:

We now always fetch the newest version tag as well as commits and check if there is any change (unpublished commit) newer than the tagged commit. This is used primarily for Version Bump that sometimes didn't read the newest tag and read the previous one instead.

If no changes or version is not bumped, the publishing will continue with warnings.