### PR TITLE
Topic/bug 30455 nuget cache

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -31,7 +31,7 @@ object DebugBuild : BuildType({
     }
 
     steps {
-        // Step to kill all dotnet or VBCSCompiler processes that might be locking files.
+        // Step to kill all dotnet or VBCSCompiler processes that might be locking files we delete in during cleaning.
         powerShell {
             scriptMode = file {
                 path = "Build.ps1"
@@ -83,7 +83,7 @@ object PublicBuild : BuildType({
     }
 
     steps {
-        // Step to kill all dotnet or VBCSCompiler processes that might be locking files.
+        // Step to kill all dotnet or VBCSCompiler processes that might be locking files we delete in during cleaning.
         powerShell {
             scriptMode = file {
                 path = "Build.ps1"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -31,6 +31,14 @@ object DebugBuild : BuildType({
     }
 
     steps {
+        // Step to kill all dotnet or VBCSCompiler processes that might be locking files.
+        powerShell {
+            scriptMode = file {
+                path = "Build.ps1"
+            }
+            noProfile = false
+            param("jetbrains_powershell_scriptArguments", "tools kill")
+        }
         powerShell {
             scriptMode = file {
                 path = "Build.ps1"
@@ -75,6 +83,14 @@ object PublicBuild : BuildType({
     }
 
     steps {
+        // Step to kill all dotnet or VBCSCompiler processes that might be locking files.
+        powerShell {
+            scriptMode = file {
+                path = "Build.ps1"
+            }
+            noProfile = false
+            param("jetbrains_powershell_scriptArguments", "tools kill")
+        }
         powerShell {
             scriptMode = file {
                 path = "Build.ps1"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -31,8 +31,9 @@ object DebugBuild : BuildType({
     }
 
     steps {
-        // Step to kill all dotnet or VBCSCompiler processes that might be locking files we delete in during cleaning.
+        // Step to kill all dotnet or VBCSCompiler processes that might be locking files we delete in during cleanup.
         powerShell {
+            name = "Kill background processes before cleanup"
             scriptMode = file {
                 path = "Build.ps1"
             }
@@ -40,6 +41,7 @@ object DebugBuild : BuildType({
             param("jetbrains_powershell_scriptArguments", "tools kill")
         }
         powerShell {
+            name = "Build [Debug]"
             scriptMode = file {
                 path = "Build.ps1"
             }
@@ -83,8 +85,9 @@ object PublicBuild : BuildType({
     }
 
     steps {
-        // Step to kill all dotnet or VBCSCompiler processes that might be locking files we delete in during cleaning.
+        // Step to kill all dotnet or VBCSCompiler processes that might be locking files we delete in during cleanup.
         powerShell {
+            name = "Kill background processes before cleanup"
             scriptMode = file {
                 path = "Build.ps1"
             }
@@ -92,6 +95,7 @@ object PublicBuild : BuildType({
             param("jetbrains_powershell_scriptArguments", "tools kill")
         }
         powerShell {
+            name = "Build [Public]"
             scriptMode = file {
                 path = "Build.ps1"
             }
@@ -125,6 +129,7 @@ object PublicDeployment : BuildType({
 
     steps {
         powerShell {
+            name = "Deploy [Public]"
             scriptMode = file {
                 path = "Build.ps1"
             }
@@ -177,6 +182,7 @@ object VersionBump : BuildType({
 
     steps {
         powerShell {
+            name = "Version Bump"
             scriptMode = file {
                 path = "Build.ps1"
             }

--- a/src/PostSharp.Engineering.BuildTools/Build/KillCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/KillCommand.cs
@@ -23,7 +23,7 @@ namespace PostSharp.Engineering.BuildTools.Build
                 .Where(
                     p =>
                     {
-                        if ( p.ProcessName.Equals( "VBCSCompiler", StringComparison.OrdinalIgnoreCase ) )
+                        if ( p.ProcessName.Equals( "VBCSCompiler", StringComparison.OrdinalIgnoreCase ) || p.ProcessName.Equals( "MSBuild", StringComparison.OrdinalIgnoreCase ) )
                         {
                             return true;
                         }

--- a/src/PostSharp.Engineering.BuildTools/Build/KillCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/KillCommand.cs
@@ -32,7 +32,9 @@ namespace PostSharp.Engineering.BuildTools.Build
                         {
                             var commandLine = GetCommandLine( p );
 
-                            if ( commandLine != null && commandLine.Contains( "VBCSCompiler", StringComparison.OrdinalIgnoreCase ) )
+                            if ( commandLine != null
+                                 && (commandLine.Contains( "VBCSCompiler", StringComparison.OrdinalIgnoreCase )
+                                     || commandLine.Contains( "MSBuild", StringComparison.OrdinalIgnoreCase )) )
                             {
                                 return true;
                             }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1132,13 +1132,13 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 var directoryInfo = new DirectoryInfo( nugetCacheDirectory );
 
                 // Delete all cached packages directories starting with 'Metalama'.
-                foreach ( var dir in directoryInfo.EnumerateDirectories( "Metalama*" ) )
+                foreach ( var dir in directoryInfo.EnumerateDirectories( "metalama*" ) )
                 {
                     DeleteDirectory( Path.Combine( nugetCacheDirectory, dir.Name ) );
                 }
                 
                 // Delete all cached packages directories starting with 'PostSharp.Engineering'.
-                foreach ( var dir in directoryInfo.EnumerateDirectories( "PostSharp.Engineering*" ) )
+                foreach ( var dir in directoryInfo.EnumerateDirectories( "postsharp.engineering*" ) )
                 {
                     DeleteDirectory( Path.Combine( nugetCacheDirectory, dir.Name ) );
                 }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1142,9 +1142,13 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 }
             }
 
-            context.Console.WriteHeading( "Cleaning NuGet cache." );
+            // NugetCache gets automatically deleted only on TeamCity.
+            if ( TeamCityHelper.IsTeamCityBuild( settings ) )
+            {
+                context.Console.WriteHeading( "Cleaning NuGet cache." );
 
-            CleanNugetCache();
+                CleanNugetCache();
+            }
 
             context.Console.WriteHeading( $"Cleaning {this.ProductName}." );
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1116,8 +1116,6 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             // Clears NuGet global-packages cache of Metalama and PostSharp.Engineering packages to prevent using old or corrupted package.
             void CleanNugetCache()
             {
-                context.Console.WriteMessage( "Cleaning NuGet cache." );
-
                 // Use dotnet command to locate nuget cache directory.
                 ToolInvocationHelper.InvokeTool(
                     context.Console,
@@ -1144,9 +1142,11 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 }
             }
 
-            context.Console.WriteHeading( $"Cleaning {this.ProductName}." );
+            context.Console.WriteHeading( "Cleaning NuGet cache." );
 
             CleanNugetCache();
+
+            context.Console.WriteHeading( $"Cleaning {this.ProductName}." );
 
             foreach ( var directory in this.AdditionalDirectoriesToClean )
             {

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
@@ -77,8 +77,9 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             if ( this.RequiresClearCache )
             {
                 writer.WriteLine(
-                    $@"        // Step to kill all dotnet or VBCSCompiler processes that might be locking files we delete in during cleaning.
+                    $@"        // Step to kill all dotnet or VBCSCompiler processes that might be locking files we delete in during cleanup.
         powerShell {{
+            name = ""Kill background processes before cleanup""
             scriptMode = file {{
                 path = ""Build.ps1""
             }}
@@ -89,6 +90,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             
             writer.WriteLine(
                 $@"        powerShell {{
+            name = ""{this.Name}""
             scriptMode = file {{
                 path = ""Build.ps1""
             }}

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
@@ -12,7 +12,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
         public string Name { get; }
 
-        public bool RequiresClearCache { get; init; } = false;
+        public bool RequiresClearCache { get; init; }
 
         public string BuildArguments { get; }
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using PostSharp.Engineering.BuildTools.ContinuousIntegration;
+using System.IO;
 using System.Linq;
 
 namespace PostSharp.Engineering.BuildTools.Build.Model
@@ -10,6 +11,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         public string ObjectName { get; }
 
         public string Name { get; }
+
+        public bool RequiresClearCache { get; init; } = false;
 
         public string BuildArguments { get; }
 
@@ -69,8 +72,23 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         root(DslContext.settingsRoot)
     }}
 
-    steps {{
+    steps {{" );
+
+            if ( this.RequiresClearCache )
+            {
+                writer.WriteLine(
+                    $@"        // Step to kill all dotnet or VBCSCompiler processes that might be locking files.
         powerShell {{
+            scriptMode = file {{
+                path = ""Build.ps1""
+            }}
+            noProfile = false
+            param(""jetbrains_powershell_scriptArguments"", ""tools kill"")
+        }}" );
+            }
+            
+            writer.WriteLine(
+                $@"        powerShell {{
             scriptMode = file {{
                 path = ""Build.ps1""
             }}

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/TeamCityBuildConfiguration.cs
@@ -77,7 +77,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             if ( this.RequiresClearCache )
             {
                 writer.WriteLine(
-                    $@"        // Step to kill all dotnet or VBCSCompiler processes that might be locking files.
+                    $@"        // Step to kill all dotnet or VBCSCompiler processes that might be locking files we delete in during cleaning.
         powerShell {{
             scriptMode = file {{
                 path = ""Build.ps1""

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
@@ -92,6 +92,24 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             VcsProvider.AzureRepos,
             "Metalama" );
 
+        public static DependencyDefinition BusinessSystems { get; } = new(
+            "BusinessSystems",
+            VcsProvider.AzureRepos,
+            "WebsitesAndBusinessSystems",
+            false );
+
+        public static DependencyDefinition HelpBrowser { get; } = new(
+            "HelpBrowser",
+            VcsProvider.AzureRepos,
+            "WebsitesAndBusinessSystems",
+            false );
+
+        public static DependencyDefinition PostSharpWeb { get; } = new(
+            "PostSharpWeb",
+            VcsProvider.AzureRepos,
+            "WebsitesAndBusinessSystems",
+            false );
+
         public static ImmutableArray<DependencyDefinition> All { get; } = ImmutableArray.Create(
             MetalamaCompiler,
             Metalama,
@@ -103,6 +121,9 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             MetalamaOpenDependencyEmbedder,
             MetalamaOpenVirtuosity,
             PostSharpEngineering,
-            MetalamaBackstage );
+            MetalamaBackstage,
+            BusinessSystems,
+            HelpBrowser,
+            PostSharpWeb );
     }
 }


### PR DESCRIPTION
1. Clean step in Build process is now deleting cached nuget packages on TeamCity
2. Builds on TeamCity are now consisting of two steps: 1. kill background processes, 2. build
3. Missing dependency definitions added.