### PR TITLE
Topic/bug 30672 mergepublisher unmerged changes

### DIFF
--- a/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
+++ b/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
@@ -49,7 +49,7 @@ namespace PostSharp.Engineering.BuildTools
                             .WithData( product )
                             .WithDescription( "Swaps deployment slots" );
 
-                        if ( product.DependencyDefinition.IsVersioned && product.MainVersionDependency == null )
+                        if ( product.DependencyDefinition.IsVersioned )
                         {
                             root.AddCommand<BumpCommand>( "bump" )
                                 .WithData( product )

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1951,21 +1951,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             // When on TeamCity, Git user credentials are set to TeamCity and if the repository is of HTTPS origin, the origin will be updated to form including Git authentication credentials.
             if ( TeamCityHelper.IsTeamCityBuild( settings ) )
             {
-                // Following configurations are set only for the current operations in the repository.
-                if ( !ToolInvocationHelper.InvokeTool(
-                        context.Console,
-                        "git",
-                        "config user.name TeamCity",
-                        context.RepoDirectory ) )
-                {
-                    return false;
-                }
-
-                if ( !ToolInvocationHelper.InvokeTool(
-                        context.Console,
-                        "git",
-                        "config user.email teamcity@postsharp.net",
-                        context.RepoDirectory ) )
+                if ( !TeamCityHelper.TrySetGitIdentityCredentials( context ) )
                 {
                     return false;
                 }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1526,6 +1526,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 // If there is a change in dependencies versions, we update BumpInfo.txt with changes.
                 if ( newBumpFileContent != oldBumpFileContent )
                 {
+                    context.Console.WriteMessage( $"'{bumpInfoFile}' contents are outdated." );
+                    
                     File.WriteAllText( bumpInfoFile, newBumpFileContent );
 
                     context.Console.WriteMessage( $"Writing '{bumpInfoFile}'." );
@@ -1997,7 +1999,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             if ( !ToolInvocationHelper.InvokeTool(
                     context.Console,
                     "git",
-                    $"commit -m \"Updated dependencies versions.\"",
+                    $"commit -m \"<<VERSION_BUMP>> Updated dependencies versions.\"",
                     context.RepoDirectory ) )
             {
                 return false;

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -1520,14 +1520,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 return false;
             }
 
-            if ( VersionHasBeenBumped( context, preparedVersionInfo.Version, lastVersionTag ) )
-            {
-                context.Console.WriteWarning( "Version has already been bumped." );
-
-                return true;
-            }
-
-            // When bumping product with MainVersionDependency it will fail if the product providing MainVersion was not bumped.
+            // For products with MainVersionDependency we always update the BumpInfo.txt to prevent perpetually outdated version if the parent product is bumped afterwards.
             if ( context.Product.MainVersionDependency != null )
             {
                 // If there is a change in dependencies versions, we update BumpInfo.txt with changes.
@@ -1543,7 +1536,18 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                         return false;
                     }
                 }
+            }
 
+            if ( VersionHasBeenBumped( context, preparedVersionInfo.Version, lastVersionTag ) )
+            {
+                context.Console.WriteWarning( "Version has been bumped." );
+
+                return true;
+            }
+
+            // When bumping product with MainVersionDependency it will fail if the product providing MainVersion was not bumped.
+            if ( context.Product.MainVersionDependency != null )
+            {
                 context.Console.WriteError(
                     $"The version would need to be bumped, but it cannot because the MainVersion is dependent on '{context.Product.MainVersionDependency.Name}'. Create a fake change in '{context.Product.MainVersionDependency.Name}' and bump this repo." );
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Publishers/MergePublisher.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Publishers/MergePublisher.cs
@@ -76,6 +76,8 @@ public class MergePublisher : IndependentPublisher
             }
         }
 
+        context.Console.WriteSuccess( "MergePublisher has finished successfully." );
+
         return SuccessCode.Success;
     }
 
@@ -192,6 +194,8 @@ public class MergePublisher : IndependentPublisher
         {
             return false;
         }
+
+        context.Console.WriteImportantMessage( "Updating versions of dependencies in 'Versions.props'." );
 
         foreach ( var dependency in context.Product.Dependencies )
         {

--- a/src/PostSharp.Engineering.BuildTools/ContinuousIntegration/TeamCityHelper.cs
+++ b/src/PostSharp.Engineering.BuildTools/ContinuousIntegration/TeamCityHelper.cs
@@ -1,5 +1,6 @@
 ﻿using PostSharp.Engineering.BuildTools.Build;
 using PostSharp.Engineering.BuildTools.Dependencies.Model;
+using PostSharp.Engineering.BuildTools.Utilities;
 using Spectre.Console;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -23,6 +24,34 @@ public static class TeamCityHelper
         teamCitySourceWriteToken = Environment.GetEnvironmentVariable( environmentVariableName );
 
         if ( teamCitySourceWriteToken == null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to set Git user credentials to TeamCity. Configurations are set only for the current repository.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public static bool TrySetGitIdentityCredentials( BuildContext context )
+    {
+        if ( !ToolInvocationHelper.InvokeTool(
+                context.Console, 
+                "git", 
+                "config user.name TeamCity",
+                context.RepoDirectory ) )
+        {
+            return false;
+        }
+
+        if ( !ToolInvocationHelper.InvokeTool(
+                context.Console, 
+                "git", 
+                "config user.email teamcity@postsharp.net",
+                context.RepoDirectory ) )
         {
             return false;
         }


### PR DESCRIPTION
30672:
Simplified MergePublisher
- Git operations can either pass or fail, no external checks if the operation can be done are in place.

30743:
Products with MainVersionDependency are checked if their version needs to be bumped.
- These products now also require BumpInfo.txt file in 'eng' directory.
- They will produce a commit-based change if there is change in dependencies versions.