### PR TITLE
#31079 Minor enhancements.

### DIFF
--- a/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
+++ b/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
@@ -82,6 +82,10 @@ namespace PostSharp.Engineering.BuildTools
                                 dependencies.AddCommand<FetchDependencyCommand>( "fetch" )
                                     .WithData( product )
                                     .WithDescription( "Fetch build dependencies from TeamCity." );
+
+                                dependencies.AddCommand<UpdateDependencyCommand>( "update" )
+                                    .WithData( product )
+                                    .WithDescription( "Updates dependencies to the newest version." );
                             } );
 
                         root.AddBranch(

--- a/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
+++ b/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
@@ -81,11 +81,11 @@ namespace PostSharp.Engineering.BuildTools
 
                                 dependencies.AddCommand<FetchDependencyCommand>( "fetch" )
                                     .WithData( product )
-                                    .WithDescription( "Fetch build dependencies from TeamCity." );
+                                    .WithDescription( "Fetch build dependencies from TeamCity but does not update a version that has already been resolved." );
 
                                 dependencies.AddCommand<UpdateDependencyCommand>( "update" )
                                     .WithData( product )
-                                    .WithDescription( "Updates dependencies to the newest version." );
+                                    .WithDescription( "Updates dependencies to the newest version available on TeamCity." );
                             } );
 
                         root.AddBranch(

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -849,7 +849,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             // If we have any non-feed dependency that does not have a resolved VersionFile, it means that we have not fetched yet. 
             if ( dependenciesOverrideFile.Dependencies.Any( d => d.Value.SourceKind != DependencySourceKind.Feed && d.Value.VersionFile == null ) )
             {
-                FetchDependencyCommand.FetchDependencies( context, configuration, dependenciesOverrideFile );
+                BaseFetchDependencyCommand.UpdateOrFetchDependencies( context, configuration, dependenciesOverrideFile, false );
 
                 dependenciesOverrideFile.LocalBuildFile = propsFilePath;
             }

--- a/src/PostSharp.Engineering.BuildTools/Build/Solutions/DotNetSolution.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Solutions/DotNetSolution.cs
@@ -25,11 +25,12 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
         {
             var resultsDirectory = context.Product.TestResultsDirectory.ToString( new BuildInfo( null!, settings.BuildConfiguration, context.Product ) );
 
+            // The additional console logger is not used on TeamCity, because it hides tests output from TeamCity.VSTest.TestAdapter in build log.
             return this.RunDotNet(
                 context,
                 settings,
                 "test",
-                $"--no-restore --logger \"trx\" --logger \"console;verbosity=minimal\" --results-directory {resultsDirectory}" );
+                $"--no-restore --logger \"trx\" {(TeamCityHelper.IsTeamCityBuild( settings ) ? "" : "--logger \"console;verbosity=minimal\"")} --results-directory {resultsDirectory}" );
         }
 
         public override bool Restore( BuildContext context, BuildSettings settings ) => this.RunDotNet( context, settings, "restore", "--no-cache" );

--- a/src/PostSharp.Engineering.BuildTools/Build/Solutions/DotNetSolution.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Solutions/DotNetSolution.cs
@@ -2,6 +2,7 @@
 
 using Newtonsoft.Json;
 using PostSharp.Engineering.BuildTools.Build.Model;
+using PostSharp.Engineering.BuildTools.ContinuousIntegration;
 using PostSharp.Engineering.BuildTools.Utilities;
 using System.Collections.Generic;
 using System.IO;
@@ -40,7 +41,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
             var binaryLogFilePath = Path.Combine(
                 context.RepoDirectory,
                 context.Product.LogsDirectory.ToString(),
-                $"{context.Product.ProductName}.{command}.binlog" );
+                $"{this.Name}.{command}.binlog" );
 
             if ( settings.ContinuousIntegration )
             {

--- a/src/PostSharp.Engineering.BuildTools/Build/Solutions/MsbuildSolution.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Solutions/MsbuildSolution.cs
@@ -18,19 +18,19 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
         public MsbuildSolution( string solutionPath ) : base( solutionPath ) { }
 
         public override bool Build( BuildContext context, BuildSettings settings )
-            => RunMsbuild( context, settings, this.SolutionPath, this.Name, "Build", "-p:RestorePackages=false" );
+            => this.RunMsbuild( context, settings, this.SolutionPath, "Build", "-p:RestorePackages=false" );
 
         public override bool Pack( BuildContext context, BuildSettings settings )
-            => RunMsbuild( context, settings, this.SolutionPath, this.Name, "Pack", "-p:RestorePackages=false" );
+            => this.RunMsbuild( context, settings, this.SolutionPath, "Pack", "-p:RestorePackages=false" );
 
         public override bool Test( BuildContext context, BuildSettings settings )
-            => RunMsbuild( context, settings, this.SolutionPath, this.Name, "Test", "-p:RestorePackages=false" );
+            => this.RunMsbuild( context, settings, this.SolutionPath, "Test", "-p:RestorePackages=false" );
 
         public override bool Restore( BuildContext context, BuildSettings settings )
         {
             if ( Path.GetExtension( this.SolutionPath ) != ".sln" )
             {
-                return RunMsbuild( context, settings, this.SolutionPath, this.Name, "Restore" );
+                return this.RunMsbuild( context, settings, this.SolutionPath, "Restore" );
             }
             else
             {
@@ -60,7 +60,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
                 {
                     context.Console.WriteMessage( $"Restoring {project}" );
 
-                    if ( !RunMsbuild( context, settings, project, this.Name, "Restore" ) )
+                    if ( !this.RunMsbuild( context, settings, project, "Restore" ) )
                     {
                         return false;
                     }
@@ -70,7 +70,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
             }
         }
 
-        private static bool RunMsbuild( BuildContext context, BuildSettings settings, string project, string solutionName, string target, string arguments = "" )
+        private bool RunMsbuild( BuildContext context, BuildSettings settings, string project, string target, string arguments = "" )
         {
             var argsBuilder = new StringBuilder();
             var path = Path.Combine( context.RepoDirectory, project );
@@ -78,7 +78,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
             var binaryLogFilePath = Path.Combine(
                 context.RepoDirectory,
                 context.Product.LogsDirectory.ToString(),
-                $"{solutionName}.{target}.binlog" );
+                $"{this.Name}.{target}.binlog" );
 
             var configurationInfo = context.Product.Configurations[settings.BuildConfiguration];
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Solutions/MsbuildSolution.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Solutions/MsbuildSolution.cs
@@ -18,19 +18,19 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
         public MsbuildSolution( string solutionPath ) : base( solutionPath ) { }
 
         public override bool Build( BuildContext context, BuildSettings settings )
-            => RunMsbuild( context, settings, this.SolutionPath, "Build", "-p:RestorePackages=false" );
+            => RunMsbuild( context, settings, this.SolutionPath, this.Name, "Build", "-p:RestorePackages=false" );
 
         public override bool Pack( BuildContext context, BuildSettings settings )
-            => RunMsbuild( context, settings, this.SolutionPath, "Pack", "-p:RestorePackages=false" );
+            => RunMsbuild( context, settings, this.SolutionPath, this.Name, "Pack", "-p:RestorePackages=false" );
 
         public override bool Test( BuildContext context, BuildSettings settings )
-            => RunMsbuild( context, settings, this.SolutionPath, "Test", "-p:RestorePackages=false" );
+            => RunMsbuild( context, settings, this.SolutionPath, this.Name, "Test", "-p:RestorePackages=false" );
 
         public override bool Restore( BuildContext context, BuildSettings settings )
         {
             if ( Path.GetExtension( this.SolutionPath ) != ".sln" )
             {
-                return RunMsbuild( context, settings, this.SolutionPath, "Restore" );
+                return RunMsbuild( context, settings, this.SolutionPath, this.Name, "Restore" );
             }
             else
             {
@@ -60,7 +60,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
                 {
                     context.Console.WriteMessage( $"Restoring {project}" );
 
-                    if ( !RunMsbuild( context, settings, project, "Restore" ) )
+                    if ( !RunMsbuild( context, settings, project, this.Name, "Restore" ) )
                     {
                         return false;
                     }
@@ -70,7 +70,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
             }
         }
 
-        private static bool RunMsbuild( BuildContext context, BuildSettings settings, string project, string target, string arguments = "" )
+        private static bool RunMsbuild( BuildContext context, BuildSettings settings, string project, string solutionName, string target, string arguments = "" )
         {
             var argsBuilder = new StringBuilder();
             var path = Path.Combine( context.RepoDirectory, project );
@@ -78,7 +78,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Solutions
             var binaryLogFilePath = Path.Combine(
                 context.RepoDirectory,
                 context.Product.LogsDirectory.ToString(),
-                $"{context.Product.ProductName}.{target}.binlog" );
+                $"{solutionName}.{target}.binlog" );
 
             var configurationInfo = context.Product.Configurations[settings.BuildConfiguration];
 

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/ConfigureDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/ConfigureDependenciesCommand.cs
@@ -79,21 +79,16 @@ public abstract class ConfigureDependenciesCommand<T> : BaseCommand<T>
             }
 
             // Executes the logic itself.
-            if ( !this.ConfigureDependency( context, dependenciesOverrideFile, dependencyDefinition, settings, out var newDependenciesOverrideFile ) )
+            if ( !this.ConfigureDependency( context, dependenciesOverrideFile, dependencyDefinition, settings ) )
             {
                 return false;
             }
-
-            if ( newDependenciesOverrideFile != null )
-            {
-                dependenciesOverrideFile = newDependenciesOverrideFile;
-            }
         }
 
-        // Fetching dependencies.
-        context.Console.WriteImportantMessage( "Fetching dependencies" );
+        // Updating dependencies.
+        context.Console.WriteImportantMessage( "Updating dependencies" );
 
-        if ( !FetchDependencyCommand.FetchDependencies( context, configuration, dependenciesOverrideFile ) )
+        if ( !BaseFetchDependencyCommand.UpdateOrFetchDependencies( context, configuration, dependenciesOverrideFile, true ) )
         {
             return false;
         }
@@ -119,6 +114,5 @@ public abstract class ConfigureDependenciesCommand<T> : BaseCommand<T>
         BuildContext context,
         DependenciesOverrideFile dependenciesOverrideFile,
         DependencyDefinition dependencyDefinition,
-        T settings,
-        out DependenciesOverrideFile? newDependenciesOverrideFile );
+        T settings );
 }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/ConfigureDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/ConfigureDependenciesCommand.cs
@@ -79,9 +79,14 @@ public abstract class ConfigureDependenciesCommand<T> : BaseCommand<T>
             }
 
             // Executes the logic itself.
-            if ( !this.ConfigureDependency( context, dependenciesOverrideFile, dependencyDefinition, settings ) )
+            if ( !this.ConfigureDependency( context, dependenciesOverrideFile, dependencyDefinition, settings, out var newDependenciesOverrideFile ) )
             {
                 return false;
+            }
+
+            if ( newDependenciesOverrideFile != null )
+            {
+                dependenciesOverrideFile = newDependenciesOverrideFile;
             }
         }
 
@@ -114,5 +119,6 @@ public abstract class ConfigureDependenciesCommand<T> : BaseCommand<T>
         BuildContext context,
         DependenciesOverrideFile dependenciesOverrideFile,
         DependencyDefinition dependencyDefinition,
-        T settings );
+        T settings,
+        out DependenciesOverrideFile? newDependenciesOverrideFile );
 }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependenciesCommandSettings.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependenciesCommandSettings.cs
@@ -10,13 +10,6 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
     /// </summary>
     public class FetchDependenciesCommandSettings : BaseDependenciesCommandSettings
     {
-        [Description(
-            "Directory into which dependency repos are expected to be. If not specified, it will default to the base directory of the current repo." )]
-        [CommandOption( "--directory" )]
-        public string? ReposDirectory { get; set; }
 
-        [Description( "Updates to the latest build" )]
-        [CommandOption( "-u|--update" )]
-        public bool Update { get; set; }
     }
 }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependencyCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependencyCommand.cs
@@ -35,7 +35,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
                 return false;
             }
 
-            if ( !FetchDependencies( context, configuration, dependenciesOverrideFile, settings ) )
+            if ( !FetchDependencies( context, configuration, dependenciesOverrideFile, settings.Update, settings ) )
             {
                 return false;
             }
@@ -52,9 +52,15 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
             BuildContext context,
             BuildConfiguration configuration,
             DependenciesOverrideFile dependenciesOverrideFile,
+            bool forceUpdate = false,
             FetchDependenciesCommandSettings? settings = null )
         {
             settings ??= new FetchDependenciesCommandSettings();
+
+            if ( !forceUpdate )
+            {
+                forceUpdate = settings.Update;
+            }
 
             DependencyDefinition? GetDependencyDefinition( KeyValuePair<string, DependencySource> dependency )
             {
@@ -100,7 +106,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
             while ( iterationDependencies.Count > 0 )
             {
                 // Download artefacts that are not transitive dependencies.
-                if ( !ResolveBuildNumbersFromBranches( context, configuration, teamcity, iterationDependencies, settings.Update ) ||
+                if ( !ResolveBuildNumbersFromBranches( context, configuration, teamcity, iterationDependencies, forceUpdate ) ||
                      !ResolveLocalDependencies( context, iterationDependencies ) )
                 {
                     return false;

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependencyCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/FetchDependencyCommand.cs
@@ -19,8 +19,9 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
     /// <summary>
     /// Fetches the artifacts of the build dependencies.
     /// </summary>
-    public class FetchDependencyCommand : BaseCommand<FetchDependenciesCommandSettings>
+    public abstract class BaseFetchDependencyCommand : BaseCommand<FetchDependenciesCommandSettings>
     {
+        protected abstract bool Update { get; }
         protected override bool ExecuteCore( BuildContext context, FetchDependenciesCommandSettings settings )
         {
             context.Console.WriteHeading( "Fetching build artifacts" );
@@ -35,7 +36,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
                 return false;
             }
 
-            if ( !FetchDependencies( context, configuration, dependenciesOverrideFile, settings.Update, settings ) )
+            if ( !UpdateOrFetchDependencies( context, configuration, dependenciesOverrideFile, this.Update ) )
             {
                 return false;
             }
@@ -48,19 +49,13 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
             return true;
         }
 
-        public static bool FetchDependencies(
+        public static bool UpdateOrFetchDependencies(
             BuildContext context,
             BuildConfiguration configuration,
             DependenciesOverrideFile dependenciesOverrideFile,
-            bool forceUpdate = false,
-            FetchDependenciesCommandSettings? settings = null )
+            bool update  )
         {
-            settings ??= new FetchDependenciesCommandSettings();
 
-            if ( !forceUpdate )
-            {
-                forceUpdate = settings.Update;
-            }
 
             DependencyDefinition? GetDependencyDefinition( KeyValuePair<string, DependencySource> dependency )
             {
@@ -106,7 +101,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
             while ( iterationDependencies.Count > 0 )
             {
                 // Download artefacts that are not transitive dependencies.
-                if ( !ResolveBuildNumbersFromBranches( context, configuration, teamcity, iterationDependencies, forceUpdate ) ||
+                if ( !ResolveBuildNumbersFromBranches( context, configuration, teamcity, iterationDependencies, update ) ||
                      !ResolveLocalDependencies( context, iterationDependencies ) )
                 {
                     return false;

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/ResetDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/ResetDependenciesCommand.cs
@@ -14,9 +14,18 @@ public class ResetDependenciesCommand : ConfigureDependenciesCommand<ResetDepend
         BuildContext context,
         DependenciesOverrideFile dependenciesOverrideFile,
         DependencyDefinition dependencyDefinition,
-        ResetDependenciesCommandSettings settings )
+        ResetDependenciesCommandSettings settings,
+        out DependenciesOverrideFile? newDependenciesOverrideFile )
     {
         dependenciesOverrideFile.Dependencies.Remove( dependencyDefinition.Name );
+
+        // Update dependency right after resetting.
+        if ( !UpdateDependencyCommand.UpdateDependency( context, out newDependenciesOverrideFile ) )
+        {
+            context.Console.WriteError( $"Could not update '{dependencyDefinition.Name}' dependency after resetting it." );
+
+            return false;
+        }
 
         return true;
     }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/ResetDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/ResetDependenciesCommand.cs
@@ -14,18 +14,9 @@ public class ResetDependenciesCommand : ConfigureDependenciesCommand<ResetDepend
         BuildContext context,
         DependenciesOverrideFile dependenciesOverrideFile,
         DependencyDefinition dependencyDefinition,
-        ResetDependenciesCommandSettings settings,
-        out DependenciesOverrideFile? newDependenciesOverrideFile )
+        ResetDependenciesCommandSettings settings )
     {
         dependenciesOverrideFile.Dependencies.Remove( dependencyDefinition.Name );
-
-        // Update dependency right after resetting.
-        if ( !UpdateDependencyCommand.UpdateDependency( context, out newDependenciesOverrideFile ) )
-        {
-            context.Console.WriteError( $"Could not update '{dependencyDefinition.Name}' dependency after resetting it." );
-
-            return false;
-        }
 
         return true;
     }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/SetDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/SetDependenciesCommand.cs
@@ -16,11 +16,9 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
             BuildContext context,
             DependenciesOverrideFile dependenciesOverrideFile,
             DependencyDefinition dependencyDefinition,
-            SetDependenciesCommandSettings settings,
-            out DependenciesOverrideFile? newDependenciesOverrideFile )
+            SetDependenciesCommandSettings settings )
         {
             DependencySource dependencySource;
-            newDependenciesOverrideFile = null;
             
             switch ( settings.Source )
             {
@@ -63,7 +61,6 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
             }
 
             dependenciesOverrideFile.Dependencies[dependencyDefinition.Name] = dependencySource;
-            newDependenciesOverrideFile = dependenciesOverrideFile;
 
             return true;
         }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/SetDependenciesCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/SetDependenciesCommand.cs
@@ -16,10 +16,12 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
             BuildContext context,
             DependenciesOverrideFile dependenciesOverrideFile,
             DependencyDefinition dependencyDefinition,
-            SetDependenciesCommandSettings settings )
+            SetDependenciesCommandSettings settings,
+            out DependenciesOverrideFile? newDependenciesOverrideFile )
         {
             DependencySource dependencySource;
-
+            newDependenciesOverrideFile = null;
+            
             switch ( settings.Source )
             {
                 case DependencySourceKind.Local:
@@ -61,6 +63,7 @@ namespace PostSharp.Engineering.BuildTools.Dependencies
             }
 
             dependenciesOverrideFile.Dependencies[dependencyDefinition.Name] = dependencySource;
+            newDependenciesOverrideFile = dependenciesOverrideFile;
 
             return true;
         }

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/UpdateDependencyCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/UpdateDependencyCommand.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+using PostSharp.Engineering.BuildTools.Build;
+using PostSharp.Engineering.BuildTools.Dependencies.Model;
+
+namespace PostSharp.Engineering.BuildTools.Dependencies;
+
+/// <summary>
+/// Updates configuration of all dependencies in the version file.
+/// </summary>
+public class UpdateDependencyCommand : BaseCommand<BaseDependenciesCommandSettings>
+{
+    protected override bool ExecuteCore( BuildContext context, BaseDependenciesCommandSettings settings )
+    {
+        context.Console.WriteHeading( "Updating dependencies" );
+
+        if ( !settings.TryGetBuildConfiguration( context, out var configuration ) )
+        {
+            return false;
+        }
+
+        if ( !DependenciesOverrideFile.TryLoad( context, configuration, out var dependenciesOverrideFile ) )
+        {
+            return false;
+        }
+
+        if ( !FetchDependencyCommand.FetchDependencies( context, configuration, dependenciesOverrideFile, true ) )
+        {
+            return false;
+        }
+
+        if ( !dependenciesOverrideFile.TrySave( context ) )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static bool UpdateDependency( BuildContext context, out DependenciesOverrideFile? newDependenciesOverrideFile )
+    {
+        var settings = new BaseDependenciesCommandSettings();
+        
+        newDependenciesOverrideFile = null;
+        
+        if ( !settings.TryGetBuildConfiguration( context, out var configuration ) )
+        {
+            return false;
+        }
+
+        if ( !DependenciesOverrideFile.TryLoad( context, configuration, out var dependenciesOverrideFile ) )
+        {
+            return false;
+        }
+
+        newDependenciesOverrideFile = dependenciesOverrideFile;
+
+        if ( !FetchDependencyCommand.FetchDependencies( context, configuration, dependenciesOverrideFile, true ) )
+        {
+            return false;
+        }
+
+        if ( !dependenciesOverrideFile.TrySave( context ) )
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/PostSharp.Engineering.BuildTools/Dependencies/UpdateDependencyCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/UpdateDependencyCommand.cs
@@ -8,63 +8,13 @@ namespace PostSharp.Engineering.BuildTools.Dependencies;
 /// <summary>
 /// Updates configuration of all dependencies in the version file.
 /// </summary>
-public class UpdateDependencyCommand : BaseCommand<BaseDependenciesCommandSettings>
+public class UpdateDependencyCommand : BaseFetchDependencyCommand
 {
-    protected override bool ExecuteCore( BuildContext context, BaseDependenciesCommandSettings settings )
-    {
-        context.Console.WriteHeading( "Updating dependencies" );
-
-        if ( !settings.TryGetBuildConfiguration( context, out var configuration ) )
-        {
-            return false;
-        }
-
-        if ( !DependenciesOverrideFile.TryLoad( context, configuration, out var dependenciesOverrideFile ) )
-        {
-            return false;
-        }
-
-        if ( !FetchDependencyCommand.FetchDependencies( context, configuration, dependenciesOverrideFile, true ) )
-        {
-            return false;
-        }
-
-        if ( !dependenciesOverrideFile.TrySave( context ) )
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    public static bool UpdateDependency( BuildContext context, out DependenciesOverrideFile? newDependenciesOverrideFile )
-    {
-        var settings = new BaseDependenciesCommandSettings();
-        
-        newDependenciesOverrideFile = null;
-        
-        if ( !settings.TryGetBuildConfiguration( context, out var configuration ) )
-        {
-            return false;
-        }
-
-        if ( !DependenciesOverrideFile.TryLoad( context, configuration, out var dependenciesOverrideFile ) )
-        {
-            return false;
-        }
-
-        newDependenciesOverrideFile = dependenciesOverrideFile;
-
-        if ( !FetchDependencyCommand.FetchDependencies( context, configuration, dependenciesOverrideFile, true ) )
-        {
-            return false;
-        }
-
-        if ( !dependenciesOverrideFile.TrySave( context ) )
-        {
-            return false;
-        }
-
-        return true;
-    }
+    protected override bool Update => true;
 }
+
+public class FetchDependencyCommand : BaseFetchDependencyCommand
+{
+    protected override bool Update => false;
+}
+


### PR DESCRIPTION
**Changes:**

**#31079:**
- Update dependencies command added.
  - `b dependencies update` now fetches and updates dependencies.
- Reset dependencies command changed.
  - `b dependencies reset` now resets selected dependencies and automatically udpates right after.

**#31102:**
- Binary logs are now correctly generated with a separate name for each corresponding solution/projects instead of rewriting the same files.
 
 **#31084:**
- Fixed tests output not being part of build log on TeamCity
  - The root cause was additional logger was affecting console output, the logger is now not added to `dotnet test` command while on TeamCity.
  - Tests tab is now available on TeamCity.