### PR TITLE
#31228 Changed MergePublisher to update dependencies before merging to public branch.

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -67,7 +67,7 @@ object DebugBuild : BuildType({
             watchChangesInDependencies = true
             branchFilter = "+:<default>"
             // Build will not trigger automatically if the commit message contains comment value.
-            triggerRules = "-:comment=<<VERSION_BUMP>>:**"
+            triggerRules = "-:comment=<<VERSION_BUMP>>|<<DEPENDENCIES_UPDATED>>:**"
         }        
 
     }

--- a/src/PostSharp.Engineering.BuildTools/Build/Triggers/SourceBuildTrigger.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Triggers/SourceBuildTrigger.cs
@@ -20,7 +20,7 @@ public class SourceBuildTrigger : IBuildTrigger
             watchChangesInDependencies = {this.WatchChangesInDependencies.ToString().ToLowerInvariant()}
             branchFilter = ""+:<default>""
             // Build will not trigger automatically if the commit message contains comment value.
-            triggerRules = ""-:comment=<<VERSION_BUMP>>:**""
+            triggerRules = ""-:comment=<<VERSION_BUMP>>|<<DEPENDENCIES_UPDATED>>:**""
         }}        " );
     }
 }


### PR DESCRIPTION
#31228 Merge conflicts:
- Merge conflict should be now prevented as all changes will now happen on default (i.e. *dev*) branch, where we now update dependencies for public branch, instead of making changes separaretly on public branch that could lead to potential merge conflict.
- This also means the public branch will always be up to date and it's not necessary to merge back to development branch anymore.