### PR TITLE
#32126 Renaming

### DIFF
--- a/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
+++ b/src/PostSharp.Engineering.BuildTools/Dependencies/Model/Dependencies.cs
@@ -46,8 +46,15 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
         public static DependencyDefinition MetalamaOpenVirtuosity { get; } =
             new( "Metalama.Open.Virtuosity", VcsProvider.GitHub, "Metalama.MetalamaOpen" );
 
+        [Obsolete( "Renamed to MetalamaExtensions" )]
         public static DependencyDefinition MetalamaFrameworkExtensions { get; } =
             new( "Metalama.Framework.Extensions", VcsProvider.GitHub, "Metalama" );
+
+        public static DependencyDefinition MetalamaExtensions { get; } =
+            new( "Metalama.Extensions", VcsProvider.GitHub, "Metalama" );
+
+        public static DependencyDefinition MetalamaMigration { get; } =
+            new DependencyDefinition( "Metalama.Migration", VcsProvider.GitHub, "Metalama.Migration" );
 
         // This is only used from the project template.
         public static DependencyDefinition MyProduct { get; } =
@@ -106,7 +113,8 @@ namespace PostSharp.Engineering.BuildTools.Dependencies.Model
             MetalamaOpenAutoCancellationToken,
             MetalamaOpenCostura,
             MetalamaOpenVirtuosity,
-            MetalamaFrameworkExtensions,
+            MetalamaExtensions,
+            MetalamaMigration,
             PostSharpEngineering,
             MetalamaBackstage,
             BusinessSystems,


### PR DESCRIPTION
Changes:
* Renamed dependency `Metalama.Framework.Extensions` to `Metalama.Extensions`.
* Added new product `Metalama.Migrations` dependency definition.