### PR TITLE
#31136, #32122, #31085

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -24,7 +24,7 @@ object DebugBuild : BuildType({
 
     name = "Build [Debug]"
 
-    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private\n+:artifacts/logs/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/AssemblyLocator/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CompileTime/**/.completed=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CompileTimeTroubleshooting/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CrashReports/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/Extract/**/.completed=>logs\n+:%system.teamcity.build.tempDir%/Metalama/ExtractExceptions/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/Logs/**/*=>logs"
+    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private\n+:artifacts/testResults/**/*=>artifacts/testResults\n+:artifacts/logs/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/AssemblyLocator/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CompileTime/**/.completed=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CompileTimeTroubleshooting/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CrashReports/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/Extract/**/.completed=>logs\n+:%system.teamcity.build.tempDir%/Metalama/ExtractExceptions/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/Logs/**/*=>logs"
 
     vcs {
         root(DslContext.settingsRoot)
@@ -78,7 +78,7 @@ object PublicBuild : BuildType({
 
     name = "Build [Public]"
 
-    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private\n+:artifacts/logs/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/AssemblyLocator/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CompileTime/**/.completed=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CompileTimeTroubleshooting/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CrashReports/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/Extract/**/.completed=>logs\n+:%system.teamcity.build.tempDir%/Metalama/ExtractExceptions/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/Logs/**/*=>logs"
+    artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private\n+:artifacts/testResults/**/*=>artifacts/testResults\n+:artifacts/logs/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/AssemblyLocator/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CompileTime/**/.completed=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CompileTimeTroubleshooting/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/CrashReports/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/Extract/**/.completed=>logs\n+:%system.teamcity.build.tempDir%/Metalama/ExtractExceptions/**/*=>logs\n+:%system.teamcity.build.tempDir%/Metalama/Logs/**/*=>logs"
 
     vcs {
         root(DslContext.settingsRoot)
@@ -162,7 +162,7 @@ object PublicDeployment : BuildType({
 
             artifacts {
                 cleanDestination = true
-                artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private"
+                artifactRules = "+:artifacts/publish/public/**/*=>artifacts/publish/public\n+:artifacts/publish/private/**/*=>artifacts/publish/private\n+:artifacts/testResults/**/*=>artifacts/testResults"
             }
         }
 

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/DefaultBumpStrategy.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/DefaultBumpStrategy.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace PostSharp.Engineering.BuildTools.Build.Model;
+
+internal class DefaultBumpStrategy : IBumpStrategy
+{
+    public bool TryBumpVersion(
+        Product product,
+        BuildContext context,
+        [NotNullWhen( true )] out Version? oldVersion,
+        [NotNullWhen( true )] out Version? newVersion )
+    {
+        var mainVersionFile = Path.Combine(
+            context.RepoDirectory,
+            product.MainVersionFilePath );
+
+        if ( !File.Exists( mainVersionFile ) )
+        {
+            context.Console.WriteError( $"The file '{mainVersionFile}' does not exist." );
+
+            oldVersion = null;
+            newVersion = null;
+
+            return false;
+        }
+
+        var currentMainVersionFile = product.ReadMainVersionFile( mainVersionFile );
+
+        oldVersion = new Version( currentMainVersionFile.MainVersion );
+
+        // Increment the version.
+        newVersion = new Version(
+            oldVersion.Major,
+            oldVersion.Minor,
+            oldVersion.Build + 1 );
+
+        // Save the MainVersion.props with new version.
+        if ( !TrySaveMainVersion( context, mainVersionFile, newVersion, null ) )
+        {
+            return false;
+        }
+
+        context.Console.WriteSuccess( $"Bumping the '{context.Product.ProductName}' version from '{oldVersion}' to '{newVersion}' was successful." );
+
+        return true;
+    }
+
+    private static bool TrySaveMainVersion(
+        BuildContext context,
+        string mainVersionFile,
+        Version version,
+        int? patchNumber )
+    {
+        if ( !File.Exists( mainVersionFile ) )
+        {
+            context.Console.WriteError( $"Could not save '{mainVersionFile}': the file does not exist." );
+
+            return false;
+        }
+
+        var document = XDocument.Load( mainVersionFile );
+        var project = document.Root;
+        var properties = project!.Element( "PropertyGroup" );
+        var mainVersionElement = properties!.Element( "MainVersion" );
+        var ourPatchVersionElement = properties.Element( "OurPatchVersion" );
+
+        // If OurPatchVersion is defined in MainVersion.props, we write the incremented patch number to it.
+        if ( patchNumber != null && ourPatchVersionElement != null )
+        {
+            ourPatchVersionElement.Value = patchNumber.Value.ToString( CultureInfo.InvariantCulture );
+        }
+
+        // Otherwise we replace the whole MainVersion with new version.
+        else
+        {
+            mainVersionElement!.Value = version.ToString();
+        }
+
+        // Using settings to keep the indentation as well as encoding identical to original MainVersion.props.
+        var xmlWriterSettings =
+            new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true, IndentChars = "    ", Encoding = new UTF8Encoding( false ) };
+
+        using ( var xmlWriter = XmlWriter.Create( mainVersionFile, xmlWriterSettings ) )
+        {
+            document.Save( xmlWriter );
+        }
+
+        context.Console.WriteMessage( $"Writing '{mainVersionFile}'." );
+
+        return true;
+    }
+}

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/IBumpStrategy.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/IBumpStrategy.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace PostSharp.Engineering.BuildTools.Build.Model;
+
+public interface IBumpStrategy
+{
+    bool TryBumpVersion(
+        Product product,
+        BuildContext context,
+        [NotNullWhen( true )] out Version? oldVersion,
+        [NotNullWhen( true )] out Version? newVersion );
+}

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/PatchVersionBumpStrategy.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/PatchVersionBumpStrategy.cs
@@ -10,7 +10,7 @@ using System.Xml.Linq;
 
 namespace PostSharp.Engineering.BuildTools.Build.Model;
 
-internal class DefaultBumpStrategy : IBumpStrategy
+public class PatchVersionBumpStrategy : IBumpStrategy
 {
     public bool TryBumpVersion(
         Product product,
@@ -33,30 +33,42 @@ internal class DefaultBumpStrategy : IBumpStrategy
         }
 
         var currentMainVersionFile = product.ReadMainVersionFile( mainVersionFile );
-
+        var oldOurPatchVersion = currentMainVersionFile.OurPatchVersion;
         oldVersion = new Version( currentMainVersionFile.MainVersion );
 
-        // Increment the version.
-        newVersion = new Version(
-            oldVersion.Major,
-            oldVersion.Minor,
-            oldVersion.Build + 1 );
-
-        // Save the MainVersion.props with new version.
-        if ( !TrySaveMainVersion( context, mainVersionFile, newVersion ) )
+        if ( oldOurPatchVersion == null )
         {
+            context.Console.WriteError( "OurPatchVersion property value is null." );
+            oldVersion = null;
+            newVersion = null;
+            
             return false;
         }
+        
+        // Increment the version.
+        var newOurPatchVersion = oldOurPatchVersion + 1;
 
+        // Save the MainVersion.props with new version.
+        if ( !TrySavePatchedMainVersion( context, mainVersionFile, newOurPatchVersion.Value ) )
+        {
+            oldVersion = null;
+            newVersion = null;
+
+            return false;
+        }
+        
+        var updatedMainVersionFile = product.ReadMainVersionFile( mainVersionFile );
+        newVersion = new Version( updatedMainVersionFile.MainVersion );
+        
         context.Console.WriteSuccess( $"Bumping the '{context.Product.ProductName}' version from '{oldVersion}' to '{newVersion}' was successful." );
 
         return true;
     }
 
-    private static bool TrySaveMainVersion(
+    private static bool TrySavePatchedMainVersion(
         BuildContext context,
         string mainVersionFile,
-        Version version )
+        int ourPatchVersion )
     {
         if ( !File.Exists( mainVersionFile ) )
         {
@@ -68,10 +80,17 @@ internal class DefaultBumpStrategy : IBumpStrategy
         var document = XDocument.Load( mainVersionFile );
         var project = document.Root;
         var properties = project!.Element( "PropertyGroup" );
-        var mainVersionElement = properties!.Element( "MainVersion" );
-        var ourPatchVersionElement = properties.Element( "OurPatchVersion" );
+        var ourPatchVersionElement = properties!.Element( "OurPatchVersion" );
 
-        mainVersionElement!.Value = version.ToString();
+        // Fail on missing <OurPatchVersion> property or replace its value.
+        if ( ourPatchVersionElement == null )
+        {
+            context.Console.WriteError( $"OurPatchVersion property is missing in '{mainVersionFile}'" );
+
+            return false;
+        }
+
+        ourPatchVersionElement.Value = ourPatchVersion.ToString( CultureInfo.InvariantCulture );
 
         // Using settings to keep the indentation as well as encoding identical to original MainVersion.props.
         var xmlWriterSettings =

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -667,6 +667,20 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 }
             }
 
+            if ( !Directory.Exists( this.TestResultsDirectory.ToString() ) )
+            {
+                Directory.CreateDirectory( this.TestResultsDirectory.ToString() );
+            }
+
+            if ( !Directory.GetFiles( this.TestResultsDirectory.ToString() ).Any() )
+            {
+                // We have to create an empty file, otherwise TeamCity will complain that
+                // artifacts are missing.
+                var emptyFile = Path.Combine( this.TestResultsDirectory.ToString(), ".empty" );
+
+                File.WriteAllText( emptyFile, "This file is intentionally empty." );
+            }
+
             context.Console.WriteSuccess( $"Testing {this.ProductName} was successful" );
 
             return true;

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -67,7 +67,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             get => this._bumpInfoFile ?? Path.Combine( this.EngineeringDirectory, "BumpInfo.txt" );
             init => this._bumpInfoFile = value;
         }
-        
+
         /// <summary>
         /// Gets the dependency from which the main version should be copied.
         /// </summary>
@@ -155,6 +155,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         /// Gets the set of source code dependencies of this product. 
         /// </summary>
         public DependencyDefinition[] SourceDependencies { get; init; } = Array.Empty<DependencyDefinition>();
+
+        public IBumpStrategy BumpStrategy { get; init; } = new DefaultBumpStrategy();
 
         public DependencyDefinition? GetDependency( string name )
         {
@@ -473,7 +475,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             return new BuildInfo( packageVersion, Enum.Parse<BuildConfiguration>( configuration ), this );
         }
 
-        private record MainVersionFileInfo(
+        public record MainVersionFileInfo(
             string MainVersion,
             string? OverriddenPatchVersion,
             string PackageVersionSuffix,
@@ -483,7 +485,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
         /// <summary>
         /// Reads MainVersion.props but does not interpret anything.
         /// </summary>
-        private MainVersionFileInfo ReadMainVersionFile( string path )
+        public MainVersionFileInfo ReadMainVersionFile( string path )
         {
             var versionFilePath = path;
             var versionFile = Project.FromFile( versionFilePath, new ProjectOptions() );
@@ -1433,11 +1435,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
         public bool SwapAfterPublishing( BuildContext context, PublishSettings publishSettings )
         {
-            var swapSettings = new SwapSettings()
-            {
-                BuildConfiguration = publishSettings.BuildConfiguration,
-                Dry = publishSettings.Dry,
-            };
+            var swapSettings = new SwapSettings() { BuildConfiguration = publishSettings.BuildConfiguration, Dry = publishSettings.Dry };
 
             return this.Swap( context, swapSettings );
         }
@@ -1466,7 +1464,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
                                     // If any of the testers fail during swap, we do swap again to get the slots to their original state.
                                     case SuccessCode.Error:
-                                        context.Console.WriteError( $"Tester failed after swapping staging and production slots. Attempting to revert the swap." );
+                                        context.Console.WriteError(
+                                            $"Tester failed after swapping staging and production slots. Attempting to revert the swap." );
 
                                         switch ( swapper.Execute( context, settings, configuration ) )
                                         {
@@ -1577,7 +1576,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
             if ( this.MainVersionDependency == null )
             {
-                if ( !this.TryBumpVersion( context, out oldVersion, out newVersion ) )
+                if ( !this.BumpStrategy.TryBumpVersion( this, context, out oldVersion, out newVersion ) )
                 {
                     return false;
                 }
@@ -1966,46 +1965,6 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             return true;
         }
 
-        private bool TryBumpVersion(
-            BuildContext context,
-            [NotNullWhen( true )] out Version? oldVersion,
-            [NotNullWhen( true )] out Version? newVersion )
-        {
-            var mainVersionFile = Path.Combine(
-                context.RepoDirectory,
-                this.MainVersionFilePath );
-
-            if ( !File.Exists( mainVersionFile ) )
-            {
-                context.Console.WriteError( $"The file '{mainVersionFile}' does not exist." );
-
-                oldVersion = null;
-                newVersion = null;
-
-                return false;
-            }
-
-            var currentMainVersionFile = this.ReadMainVersionFile( mainVersionFile );
-
-            oldVersion = new Version( currentMainVersionFile.MainVersion );
-
-            // Increment the version.
-            newVersion = new Version(
-                oldVersion.Major,
-                oldVersion.Minor,
-                oldVersion.Build + 1 );
-
-            // Save the MainVersion.props with new version.
-            if ( !TrySaveMainVersion( context, mainVersionFile, newVersion, null ) )
-            {
-                return false;
-            }
-
-            context.Console.WriteSuccess( $"Bumping the '{context.Product.ProductName}' version from '{oldVersion}' to '{newVersion}' was successful." );
-
-            return true;
-        }
-
         private bool TryCommitVersionBump( BuildContext context, Version? currentVersion, Version newVersion, CommonCommandSettings settings )
         {
             // Adds bumped MainVersion.props and updated BumpInfo.txt to Git staging area.
@@ -2145,51 +2104,6 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
             }
 
             preparedVersionInfo = new PreparedVersionInfo( currentVersion, mainVersionFileInfo.PackageVersionSuffix );
-
-            return true;
-        }
-
-        private static bool TrySaveMainVersion(
-            BuildContext context,
-            string mainVersionFile,
-            Version version,
-            int? patchNumber )
-        {
-            if ( !File.Exists( mainVersionFile ) )
-            {
-                context.Console.WriteError( $"Could not save '{mainVersionFile}': the file does not exist." );
-
-                return false;
-            }
-
-            var document = XDocument.Load( mainVersionFile );
-            var project = document.Root;
-            var properties = project!.Element( "PropertyGroup" );
-            var mainVersionElement = properties!.Element( "MainVersion" );
-            var ourPatchVersionElement = properties.Element( "OurPatchVersion" );
-
-            // If OurPatchVersion is defined in MainVersion.props, we write the incremented patch number to it.
-            if ( patchNumber != null && ourPatchVersionElement != null )
-            {
-                ourPatchVersionElement.Value = patchNumber.Value.ToString( CultureInfo.InvariantCulture );
-            }
-
-            // Otherwise we replace the whole MainVersion with new version.
-            else
-            {
-                mainVersionElement!.Value = version.ToString();
-            }
-
-            // Using settings to keep the indentation as well as encoding identical to original MainVersion.props.
-            var xmlWriterSettings =
-                new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true, IndentChars = "    ", Encoding = new UTF8Encoding( false ) };
-
-            using ( var xmlWriter = XmlWriter.Create( mainVersionFile, xmlWriterSettings ) )
-            {
-                document.Save( xmlWriter );
-            }
-
-            context.Console.WriteMessage( $"Writing '{mainVersionFile}'." );
 
             return true;
         }

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -102,8 +102,6 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
         public Pattern PublicArtifacts { get; init; } = Pattern.Empty;
 
-        public bool PublishTestResults { get; init; }
-
         public VcsProvider? VcsProvider { get; }
 
         public bool KeepEditorConfig { get; init; }
@@ -1660,10 +1658,8 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
                 var artifactRules =
                     $@"+:{publicArtifactsDirectory}/**/*=>{publicArtifactsDirectory}\n+:{privateArtifactsDirectory}/**/*=>{privateArtifactsDirectory}";
 
-                if ( context.Product.PublishTestResults )
-                {
-                    artifactRules += $@"\n+:{testResultsDirectory}/**/*=>{testResultsDirectory}";
-                }
+                // Add testResults to artifacts
+                artifactRules += $@"\n+:{testResultsDirectory}/**/*=>{testResultsDirectory}";
 
                 if ( context.Product.SourceDependencies.Length > 0 )
                 {

--- a/src/PostSharp.Engineering.BuildTools/ContinuousIntegration/TeamCityServiceMessageProvider.cs
+++ b/src/PostSharp.Engineering.BuildTools/ContinuousIntegration/TeamCityServiceMessageProvider.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+using System;
+
+namespace PostSharp.Engineering.BuildTools.ContinuousIntegration;
+
+public static class TeamCityServiceMessageProvider
+{
+    public static void SendImportDataMessage( string type, string path, string flowId )
+    {
+        var date = DateTimeOffset.Now;
+        var timestamp = $"{date:yyyy-MM-dd'T'HH:mm:ss.fff}{date.Offset.Ticks:+;-;}{date.Offset:hhmm}";
+
+        Console.WriteLine(
+            "##teamcity[importData type='{0}' path='{1}' flowId='{2}' timestamp='{3}' whenNoDataPublished='error']",
+            type,
+            path,
+            flowId,
+            timestamp );
+    }
+}

--- a/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationHelper.cs
+++ b/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationHelper.cs
@@ -46,7 +46,7 @@ namespace PostSharp.Engineering.BuildTools.Utilities
             }
             else if ( exitCode != 0 )
             {
-                console.WriteError( "The process \"{0}\" failed with exit code {1}.", fileName, exitCode );
+                console.WriteError( $"The process `\"{fileName}\" {commandLine}` failed with exit code {exitCode}." );
 
                 return false;
             }


### PR DESCRIPTION
#31136:
- Separate bump strategy for standard products and products with PatchVersion
#32122:
- artifacts/testResults are now correctly exported to TeamCity artifacts
#31085:
- Build log clean of TeamCity service messages, instead the test results are exported to TeamCity to include Tests tab