### PR TITLE
#32241 Upgrade BuildAgentType, Fix for .NET 7 SDK.

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -51,7 +51,7 @@ object DebugBuild : BuildType({
     }
 
     requirements {
-        equals("env.BuildAgentType", "caravela03")
+        equals("env.BuildAgentType", "caravela04")
     }
 
     features {
@@ -105,7 +105,7 @@ object PublicBuild : BuildType({
     }
 
     requirements {
-        equals("env.BuildAgentType", "caravela03")
+        equals("env.BuildAgentType", "caravela04")
     }
 
     features {
@@ -139,7 +139,7 @@ object PublicDeployment : BuildType({
     }
 
     requirements {
-        equals("env.BuildAgentType", "caravela03")
+        equals("env.BuildAgentType", "caravela04")
     }
 
     features {
@@ -192,7 +192,7 @@ object VersionBump : BuildType({
     }
 
     requirements {
-        equals("env.BuildAgentType", "caravela03")
+        equals("env.BuildAgentType", "caravela04")
     }
 
     features {

--- a/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
+++ b/src/PostSharp.Engineering.BuildTools/Build/Model/Product.cs
@@ -106,7 +106,7 @@ namespace PostSharp.Engineering.BuildTools.Build.Model
 
         public bool KeepEditorConfig { get; init; }
 
-        public string BuildAgentType { get; init; } = "caravela03";
+        public string BuildAgentType { get; init; } = "caravela04";
 
         public ConfigurationSpecific<BuildConfigurationInfo> Configurations { get; init; } = DefaultConfigurations;
 

--- a/src/PostSharp.Engineering.BuildTools/Utilities/DotNetHelper.cs
+++ b/src/PostSharp.Engineering.BuildTools/Utilities/DotNetHelper.cs
@@ -53,7 +53,7 @@ namespace PostSharp.Engineering.BuildTools.Utilities
 
             argsBuilder.Append(
                 CultureInfo.InvariantCulture,
-                $"{command} -p:Configuration={configuration.MSBuildName} \"{solution}\" -v:{settings.Verbosity.ToAlias()} --nologo" );
+                $"{command} \"{solution}\" -p:Configuration={configuration.MSBuildName} -v:{settings.Verbosity.ToAlias()} --nologo" );
 
             if ( settings.NoConcurrency )
             {


### PR DESCRIPTION
Changes:
- BuildAgentType upgraded.
- Fixed MSB1011 by changing order of `dotnet` commands arguments.