### PR TITLE
#32325 Added Retry when output matches RegEx.

### DIFF
--- a/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommand.cs
@@ -110,8 +110,27 @@ public class UnlistNugetPackageCommand : Command<UnlistNugetPackageCommandSettin
     
     private static bool UnlistPackage( ConsoleHelper console, string packageName, List<string> packageVersions )
     {
-        var nugetApiKey = Environment.ExpandEnvironmentVariables( "%NUGET_ORG_UNLIST_API_KEY%" );
-        var nugetServerUrl = Environment.ExpandEnvironmentVariables( "%NUGET_ORG_GET_URL%" );
+        var nugetUnlistApiKeyEnvironmentVariable = "NUGET_ORG_UNLIST_API_KEY";
+        var nugetUnlistApiKey = Environment.GetEnvironmentVariable( nugetUnlistApiKeyEnvironmentVariable );
+
+        if ( string.IsNullOrEmpty( nugetUnlistApiKey ) )
+        {
+            console.WriteImportantMessage(
+                $"'{nugetUnlistApiKeyEnvironmentVariable}' environment variable required for unlisting the package from NuGet.org is not set." );
+
+            return false;
+        }
+
+        var nugetServerUrlEnvironmentVariable = "NUGET_ORG_GET_URL";
+        var nugetServerUrl = Environment.GetEnvironmentVariable( nugetServerUrlEnvironmentVariable );
+
+        if ( string.IsNullOrEmpty( nugetServerUrl ) )
+        {
+            console.WriteImportantMessage(
+                $"'{nugetServerUrlEnvironmentVariable}' environment variable not set. Set it to a supported server URL, e.g. 'https://www.nuget.org'." );
+
+            return false;
+        }
 
         var success = true;
 
@@ -120,7 +139,7 @@ public class UnlistNugetPackageCommand : Command<UnlistNugetPackageCommandSettin
             if ( !ToolInvocationHelper.InvokeTool(
                     console,
                     "dotnet",
-                    $"nuget delete {packageName} {version} --api-key {nugetApiKey} --non-interactive --source {nugetServerUrl}",
+                    $"nuget delete {packageName} {version} --api-key {nugetUnlistApiKey} --non-interactive --source {nugetServerUrl}",
                     Directory.GetCurrentDirectory() ) )
             {
                 success = false;

--- a/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationHelper.cs
+++ b/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationHelper.cs
@@ -207,9 +207,12 @@ namespace PostSharp.Engineering.BuildTools.Utilities
             }
 
             // Filters process output where matching RegEx value indicates process failure.
-            bool FilterProcessOutput( string output )
+            void FilterProcessOutput( string output )
             {
-                return options.Retry != null && options.Retry.Regex != null && options.Retry.Regex.IsMatch( output );
+                if ( options.Retry != null && options.Retry.Regex != null && options.Retry.Regex.IsMatch( output ) )
+                {
+                    retry = true;
+                }
             }
 
             Path.GetFileName( fileName );
@@ -228,11 +231,8 @@ namespace PostSharp.Engineering.BuildTools.Utilities
                         }
                         else
                         {
-                            if ( FilterProcessOutput( args.Data ) )
-                            {
-                                retry = true;
-                            }
-                            
+                            FilterProcessOutput( args.Data );
+
                             handleErrorData( args.Data );
                         }
                     }
@@ -252,10 +252,7 @@ namespace PostSharp.Engineering.BuildTools.Utilities
                         }
                         else
                         {
-                            if ( FilterProcessOutput( args.Data ) )
-                            {
-                                retry = true;
-                            }
+                            FilterProcessOutput( args.Data );
 
                             handleOutputData( args.Data );
                         }

--- a/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationHelper.cs
+++ b/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationHelper.cs
@@ -206,6 +206,12 @@ namespace PostSharp.Engineering.BuildTools.Utilities
                 startInfo.Environment[blockedEnvironmentVariable] = null;
             }
 
+            // Filters process output where matching RegEx value indicates process failure.
+            bool FilterProcessOutput( string output )
+            {
+                return options.Retry != null && options.Retry.Regex != null && options.Retry.Regex.IsMatch( output );
+            }
+
             Path.GetFileName( fileName );
             Process process = new() { StartInfo = startInfo };
 
@@ -222,8 +228,7 @@ namespace PostSharp.Engineering.BuildTools.Utilities
                         }
                         else
                         {
-                            // If ToolInvocationRetry.Regex matches output that causes build failure, we will set the build to retry.
-                            if ( options.Retry != null && options.Retry.Regex != null && options.Retry.Regex.IsMatch( args.Data ) )
+                            if ( FilterProcessOutput( args.Data ) )
                             {
                                 retry = true;
                             }
@@ -247,8 +252,7 @@ namespace PostSharp.Engineering.BuildTools.Utilities
                         }
                         else
                         {
-                            // If ToolInvocationRetry.Regex matches output that causes build failure, we will set the build to retry.
-                            if ( options.Retry != null && options.Retry.Regex != null && options.Retry.Regex.IsMatch( args.Data ) )
+                            if ( FilterProcessOutput( args.Data ) )
                             {
                                 retry = true;
                             }
@@ -340,7 +344,7 @@ namespace PostSharp.Engineering.BuildTools.Utilities
 
                     exitCode = process.ExitCode;
 
-                    // We will retry invocation if exit code is the one that is a reason to retry.
+                    // We will retry invocation if exit code matches the one that is a reason to retry.
                     if ( options.Retry != null && exitCode == options.Retry.ExitCode )
                     {
                         retry = true;

--- a/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationHelper.cs
+++ b/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationHelper.cs
@@ -164,208 +164,200 @@ namespace PostSharp.Engineering.BuildTools.Utilities
         {
             exitCode = 0;
             options ??= new ToolInvocationOptions();
-            var retry = false;
+            var processShouldRetry = false;
+            var retryAttempts = 3;
 
-#pragma warning disable CA1307 // There is no string.Contains that takes a StringComparison
-            if ( fileName.Contains( new string( Path.DirectorySeparatorChar, 1 ) ) && !File.Exists( fileName ) )
+            for ( var attempt = 0; attempt < retryAttempts; attempt++ )
             {
-                console.WriteError( "Cannot execute \"{0}\": file not found.", fileName );
+#pragma warning disable CA1307 // There is no string.Contains that takes a StringComparison
+                if ( fileName.Contains( new string( Path.DirectorySeparatorChar, 1 ) ) && !File.Exists( fileName ) )
+                {
+                    console.WriteError( "Cannot execute \"{0}\": file not found.", fileName );
 
-                return false;
-            }
+                    return false;
+                }
 #pragma warning restore CA1307
 
-            const int restartLimit = 3;
-            var restartCount = 0;
-        start:
+                const int restartLimit = 3;
+                var restartCount = 0;
+            start:
 
-            ProcessStartInfo startInfo =
-                new()
-                {
-                    FileName = fileName,
-                    Arguments = Environment.ExpandEnvironmentVariables( commandLine ),
-                    WorkingDirectory = workingDirectory,
-                    ErrorDialog = false,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true
-                };
-
-            if ( options.EnvironmentVariables != null )
-            {
-                foreach ( var pair in options.EnvironmentVariables )
-                {
-                    startInfo.Environment[pair.Key] = pair.Value;
-                }
-            }
-
-            // Some environment variables must not be passed from the current process to the child process.
-            foreach ( var blockedEnvironmentVariable in options.BlockedEnvironmentVariables )
-            {
-                startInfo.Environment[blockedEnvironmentVariable] = null;
-            }
-
-            // Filters process output where matching RegEx value indicates process failure.
-            void FilterProcessOutput( string output )
-            {
-                if ( options.Retry != null && options.Retry.Regex != null && options.Retry.Regex.IsMatch( output ) )
-                {
-                    retry = true;
-                }
-            }
-
-            Path.GetFileName( fileName );
-            Process process = new() { StartInfo = startInfo };
-
-            using ( ManualResetEvent stdErrorClosed = new( false ) )
-            using ( ManualResetEvent stdOutClosed = new( false ) )
-            {
-                process.ErrorDataReceived += ( _, args ) =>
-                {
-                    try
+                ProcessStartInfo startInfo =
+                    new()
                     {
-                        if ( args.Data == null )
-                        {
-                            stdErrorClosed.Set();
-                        }
-                        else
-                        {
-                            FilterProcessOutput( args.Data );
+                        FileName = fileName,
+                        Arguments = Environment.ExpandEnvironmentVariables( commandLine ),
+                        WorkingDirectory = workingDirectory,
+                        ErrorDialog = false,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true
+                    };
 
-                            handleErrorData( args.Data );
-                        }
-                    }
-                    catch ( Exception e )
-                    {
-                        console.Error.WriteException( e );
-                    }
-                };
-
-                process.OutputDataReceived += ( _, args ) =>
+                if ( options.EnvironmentVariables != null )
                 {
-                    try
+                    foreach ( var pair in options.EnvironmentVariables )
                     {
-                        if ( args.Data == null )
-                        {
-                            stdOutClosed.Set();
-                        }
-                        else
-                        {
-                            FilterProcessOutput( args.Data );
-
-                            handleOutputData( args.Data );
-                        }
+                        startInfo.Environment[pair.Key] = pair.Value;
                     }
-                    catch ( Exception e )
-                    {
-                        console.Error.WriteException( e );
-                    }
-                };
-
-                // Log the command line, but not the one with expanded environment variables, so we don't expose secrets.
-                if ( !options.Silent )
-                {
-                    console.WriteImportantMessage( "{0} {1}", process.StartInfo.FileName, commandLine );
                 }
 
-                using ( process )
+                // Some environment variables must not be passed from the current process to the child process.
+                foreach ( var blockedEnvironmentVariable in options.BlockedEnvironmentVariables )
                 {
-                    try
+                    startInfo.Environment[blockedEnvironmentVariable] = null;
+                }
+
+                // Filters process output where matching RegEx value indicates process failure.
+                void FilterProcessOutput( string output )
+                {
+                    if ( options.Retry != null && options.Retry.Regex != null && options.Retry.Regex.IsMatch( output ) )
                     {
-                        process.Start();
+                        processShouldRetry = true;
                     }
-                    catch ( Win32Exception e ) when ( (uint) e.NativeErrorCode == 0x80004005 )
+                }
+
+                Path.GetFileName( fileName );
+                Process process = new() { StartInfo = startInfo };
+
+                using ( ManualResetEvent stdErrorClosed = new( false ) )
+                using ( ManualResetEvent stdOutClosed = new( false ) )
+                {
+                    process.ErrorDataReceived += ( _, args ) =>
                     {
-                        if ( restartCount < restartLimit )
+                        try
                         {
-                            console.WriteWarning(
-                                "Access denied when starting a process. This might be caused by an anti virus software. Waiting 1000 ms and restarting." );
-
-                            Thread.Sleep( 1000 );
-                            restartCount++;
-
-                            goto start;
-                        }
-
-                        throw;
-                    }
-
-                    if ( !cancellationToken.HasValue )
-                    {
-                        process.BeginErrorReadLine();
-                        process.BeginOutputReadLine();
-                        process.WaitForExit();
-                    }
-                    else
-                    {
-                        using ( ManualResetEvent cancelledEvent = new( false ) )
-                        using ( ManualResetEvent exitedEvent = new( false ) )
-                        {
-                            process.EnableRaisingEvents = true;
-                            process.Exited += ( _, _ ) => exitedEvent.Set();
-
-                            using ( cancellationToken.Value.Register( () => cancelledEvent.Set() ) )
+                            if ( args.Data == null )
                             {
-                                process.BeginErrorReadLine();
-                                process.BeginOutputReadLine();
+                                stdErrorClosed.Set();
+                            }
+                            else
+                            {
+                                FilterProcessOutput( args.Data );
 
-                                if ( !process.HasExited )
+                                handleErrorData( args.Data );
+                            }
+                        }
+                        catch ( Exception e )
+                        {
+                            console.Error.WriteException( e );
+                        }
+                    };
+
+                    process.OutputDataReceived += ( _, args ) =>
+                    {
+                        try
+                        {
+                            if ( args.Data == null )
+                            {
+                                stdOutClosed.Set();
+                            }
+                            else
+                            {
+                                FilterProcessOutput( args.Data );
+
+                                handleOutputData( args.Data );
+                            }
+                        }
+                        catch ( Exception e )
+                        {
+                            console.Error.WriteException( e );
+                        }
+                    };
+
+                    // Log the command line, but not the one with expanded environment variables, so we don't expose secrets.
+                    if ( !options.Silent )
+                    {
+                        console.WriteImportantMessage( "{0} {1}", process.StartInfo.FileName, commandLine );
+                    }
+
+                    using ( process )
+                    {
+                        try
+                        {
+                            process.Start();
+                        }
+                        catch ( Win32Exception e ) when ( (uint) e.NativeErrorCode == 0x80004005 )
+                        {
+                            if ( restartCount < restartLimit )
+                            {
+                                console.WriteWarning(
+                                    "Access denied when starting a process. This might be caused by an anti virus software. Waiting 1000 ms and restarting." );
+
+                                Thread.Sleep( 1000 );
+                                restartCount++;
+
+                                goto start;
+                            }
+
+                            throw;
+                        }
+
+                        if ( !cancellationToken.HasValue )
+                        {
+                            process.BeginErrorReadLine();
+                            process.BeginOutputReadLine();
+                            process.WaitForExit();
+                        }
+                        else
+                        {
+                            using ( ManualResetEvent cancelledEvent = new( false ) )
+                            using ( ManualResetEvent exitedEvent = new( false ) )
+                            {
+                                process.EnableRaisingEvents = true;
+                                process.Exited += ( _, _ ) => exitedEvent.Set();
+
+                                using ( cancellationToken.Value.Register( () => cancelledEvent.Set() ) )
                                 {
-                                    var signal = WaitHandle.WaitAny( new WaitHandle[] { exitedEvent, cancelledEvent } );
+                                    process.BeginErrorReadLine();
+                                    process.BeginOutputReadLine();
 
-                                    if ( signal == 1 )
+                                    if ( !process.HasExited )
                                     {
-                                        cancellationToken.Value.ThrowIfCancellationRequested();
+                                        var signal = WaitHandle.WaitAny( new WaitHandle[] { exitedEvent, cancelledEvent } );
+
+                                        if ( signal == 1 )
+                                        {
+                                            cancellationToken.Value.ThrowIfCancellationRequested();
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
 
-                    // We will wait for a while for all output to be processed.
-                    if ( !cancellationToken.HasValue )
-                    {
-                        WaitHandle.WaitAll( new WaitHandle[] { stdErrorClosed, stdOutClosed }, 10000 );
-                    }
-                    else
-                    {
-                        var i = 0;
-
-                        while ( !WaitHandle.WaitAll( new WaitHandle[] { stdErrorClosed, stdOutClosed }, 100 ) &&
-                                i++ < 100 )
+                        // We will wait for a while for all output to be processed.
+                        if ( !cancellationToken.HasValue )
                         {
-                            cancellationToken.Value.ThrowIfCancellationRequested();
+                            WaitHandle.WaitAll( new WaitHandle[] { stdErrorClosed, stdOutClosed }, 10000 );
                         }
-                    }
+                        else
+                        {
+                            var i = 0;
 
-                    exitCode = process.ExitCode;
+                            while ( !WaitHandle.WaitAll( new WaitHandle[] { stdErrorClosed, stdOutClosed }, 100 ) &&
+                                    i++ < 100 )
+                            {
+                                cancellationToken.Value.ThrowIfCancellationRequested();
+                            }
+                        }
 
-                    // We will retry invocation if exit code matches the one that is a reason to retry.
-                    if ( options.Retry != null && exitCode == options.Retry.ExitCode )
-                    {
-                        retry = true;
-                    }
-                    
-                    if ( retry )
-                    {
-                        console.WriteWarning( "Build failed. Retrying." );
+                        exitCode = process.ExitCode;
 
-                        return InvokeTool(
-                            console,
-                            fileName,
-                            commandLine,
-                            workingDirectory,
-                            cancellationToken,
-                            out exitCode,
-                            handleErrorData,
-                            handleOutputData,
-                            options );
+                        // We will retry if the process output indicates we should retry and exit code indicates failure.
+                        if ( processShouldRetry && options.Retry != null && exitCode == options.Retry.ExitCode )
+                        {
+                            console.WriteWarning( "Build failed. Retrying." );
+
+                            continue;
+                        }
+
+                        return true;
                     }
-                    
-                    return true;
                 }
             }
+
+            return true;
         }
     }
 }

--- a/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationOptions.cs
+++ b/src/PostSharp.Engineering.BuildTools/Utilities/ToolInvocationOptions.cs
@@ -1,15 +1,19 @@
 ﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
 using System.Collections.Immutable;
+using System.Text.RegularExpressions;
 
 namespace PostSharp.Engineering.BuildTools.Utilities;
 
 public record ToolInvocationOptions(
     ImmutableDictionary<string, string?>? EnvironmentVariables = null,
     bool Silent = false,
-    ImmutableArray<string> BlockedEnvironmentVariables = default )
+    ImmutableArray<string> BlockedEnvironmentVariables = default,
+    ToolInvocationRetry? Retry = null )
 {
     // Some environment variables are set by the Microsoft.Build package and must not be passed to the child process.
     public ImmutableArray<string> BlockedEnvironmentVariables { get; init; } =
         BlockedEnvironmentVariables.IsDefault ? ImmutableArray.Create( "DOTNET_ROOT_X64", "MSBUILD_EXE_PATH", "MSBuildSDKsPath" ) : BlockedEnvironmentVariables;
 }
+
+public record ToolInvocationRetry( Regex? Regex, int? ExitCode );


### PR DESCRIPTION
Changes:
* When output matches Regex set by `ToolInvocationOptions` from `ToolInvocationRetry` the build is set to retry.
* When exit code matches specific exit code from `ToolInvocationRetry`, the build is set to retry as well.