### PR TITLE
Topic/story 32333 unlist nuget packages tool

### DIFF
--- a/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
+++ b/src/PostSharp.Engineering.BuildTools/AppExtensions.cs
@@ -137,6 +137,9 @@ namespace PostSharp.Engineering.BuildTools
                                         nuget.AddCommand<VerifyPublicPackageCommand>( "verify-public" )
                                             .WithDescription(
                                                 "Verifies that all packages in a directory have only references to packages published on nuget.org." );
+
+                                        nuget.AddCommand<UnlistNugetPackageCommand>( "unlist" )
+                                            .WithDescription( "Unlists package published on nuget.org." );
                                     } );
 
                                 tools.AddBranch(

--- a/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommand.cs
@@ -74,6 +74,10 @@ public class UnlistNugetPackageCommand : Command<UnlistNugetPackageCommandSettin
         catch ( Exception e )
         {
             console.WriteError( e.Message );
+
+            packageVersionsJson = null;
+
+            return false;
         }
 
         if ( string.IsNullOrEmpty( versionsJson ) )

--- a/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommand.cs
@@ -32,13 +32,15 @@ public class UnlistNugetPackageCommand : Command<UnlistNugetPackageCommandSettin
         
         if ( !TryGetAllPackageVersions( console, packageName, out var versions ) )
         {
-            console.WriteError( $"Failed to get all versions of '{settings.PackageName}' nuget package." );
+            console.WriteError( $"Failed to get all versions of '{packageName}' package." );
 
             return false;
         }
 
         if ( !UnlistPackage( console, packageName, versions ) ) 
         {
+            console.WriteError( $"Failed to unlist all package versions of '{packageName}'." );
+
             return false;
         }
         

--- a/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommand.cs
+++ b/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommand.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+using Newtonsoft.Json;
+using PostSharp.Engineering.BuildTools.Utilities;
+using Spectre.Console.Cli;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+
+#pragma warning disable 8765
+
+namespace PostSharp.Engineering.BuildTools.NuGet;
+
+public class UnlistNugetPackageCommand : Command<UnlistNugetPackageCommandSettings>
+{
+    public override int Execute( CommandContext context, UnlistNugetPackageCommandSettings settings )
+    {
+        return Execute( new ConsoleHelper(), settings ) ? 0 : 1;
+    }
+    
+    public static bool Execute( ConsoleHelper console, UnlistNugetPackageCommandSettings settings )
+    {
+        if ( string.IsNullOrEmpty( settings.PackageName ) )
+        {
+            console.WriteError( "No package specified for unlisting from NuGet." );
+
+            return false;
+        }
+        
+        var packageName = settings.PackageName.ToLowerInvariant();
+        
+        if ( !TryGetAllPackageVersions( console, packageName, out var versions ) )
+        {
+            console.WriteError( $"Failed to get all versions of '{settings.PackageName}' nuget package." );
+
+            return false;
+        }
+
+        if ( !UnlistPackage( console, packageName, versions ) ) 
+        {
+            return false;
+        }
+        
+        console.WriteSuccess( $"Successfully unlisted all versions of '{packageName}' package." );
+
+        return true;
+    }
+
+    private static bool TryGetAllPackageVersions( ConsoleHelper console, string packageName, [NotNullWhen( true )] out List<string>? versions )
+    {
+        var httpClient = new HttpClient();
+
+        string? versionsJson = null;
+
+        try
+        {
+            versionsJson = httpClient.GetStringAsync( $"https://api.nuget.org/v3-flatcontainer/{packageName}/index.json" ).Result;
+        }
+        catch ( Exception e )
+        {
+            console.WriteError(
+                e.Message.Contains( "404", StringComparison.OrdinalIgnoreCase )
+                    ? $"NuGet package '{packageName}' not found."
+                    : e.Message );
+        }
+
+        if ( string.IsNullOrEmpty( versionsJson ) )
+        {
+            versions = null;
+
+            return false;
+        }
+
+        var deserializedVersions = JsonConvert.DeserializeObject<Versions>( versionsJson );
+
+        if ( deserializedVersions == null || deserializedVersions.VersionsList == null )
+        {
+            versions = null;
+
+            return false;
+        }
+
+        versions = deserializedVersions.VersionsList;
+
+        return true;
+    }
+    
+    private static bool UnlistPackage( ConsoleHelper console, string packageName, List<string> packageVersions )
+    {
+        console.WriteMessage( $"Unlisting all versions of package '{packageName}'." );
+
+        var nugetApiKey = Environment.ExpandEnvironmentVariables( "%NUGET_ORG_UNLIST_API_KEY%" );
+        var nugetServerUrl = Environment.ExpandEnvironmentVariables( "%NUGET_ORG_GET_URL%" );
+
+        var success = true;
+
+        foreach ( var version in packageVersions )
+        {
+            if ( !ToolInvocationHelper.InvokeTool(
+                    console,
+                    "dotnet",
+                    $"nuget delete {packageName} {version} --api-key {nugetApiKey} --non-interactive --source {nugetServerUrl}",
+                    "" ) )
+            {
+                success = false;
+            }
+        }
+
+        return success;
+    }
+
+    internal class Versions
+    {
+        [JsonProperty( "versions" )]
+        public List<string>? VersionsList { get; set; }
+    }
+}

--- a/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommandSettings.cs
+++ b/src/PostSharp.Engineering.BuildTools/NuGet/UnlistNugetPackageCommandSettings.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace PostSharp.Engineering.BuildTools.NuGet;
+
+public class UnlistNugetPackageCommandSettings : CommonCommandSettings
+{
+    [Description( "NuGet package name." )]
+    [CommandArgument( 0, "<Package.Name>" )]
+    public string? PackageName { get; set; }
+}


### PR DESCRIPTION
Changes:
* New command `.\Build.ps1 tools nuget unlist <package>` to unlist all versions of the specified NuGet package.